### PR TITLE
Add form field names for maintenance persistence

### DIFF
--- a/jsp/checklist/aireCondicionado/Header.jsp
+++ b/jsp/checklist/aireCondicionado/Header.jsp
@@ -33,17 +33,17 @@
       <div class="col-span-2">
         <div class="mb-4">
           <label class="block text-sm font-semibold text-gray-700">Cliente</label>
-          <input type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+          <input type="text" name="cliente" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
         </div>
 
         <div class="grid grid-cols-2 gap-4">
           <div>
             <label class="block text-sm font-semibold text-gray-700">Área</label>
-            <input type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="text" name="area" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
           </div>
           <div>
             <label class="block text-sm font-semibold text-gray-700">Plaza</label>
-            <input type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="text" name="plaza" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
           </div>
         </div>
       </div>
@@ -51,17 +51,17 @@
       <div>
         <div class="mb-4">
           <label class="block text-sm font-semibold text-gray-700">Unidad</label>
-          <input type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+            <input type="text" name="unidad" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
         </div>
 
         <div class="grid grid-cols-2 gap-4">
           <div>
             <label class="block text-sm font-semibold text-gray-700">Fecha</label>
-            <input type="date" id="fecha" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="date" id="fecha" name="fecha" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
           </div>
           <div>
             <label class="block text-sm font-semibold text-gray-700">Hora de Entrada</label>
-            <input type="time" id="hora" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="time" id="hora" name="horaEntrada" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
           </div>
         </div>
       </div>

--- a/jsp/checklist/aireCondicionado/ServicesSection.jsp
+++ b/jsp/checklist/aireCondicionado/ServicesSection.jsp
@@ -27,13 +27,13 @@
       <tbody id="servicesBody">
         <tr>
           <td class="py-2 px-2 border-b border-r border-gray-300">
-            <input type="text" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+            <input type="text" name="serviceQuantity[]" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
           </td>
           <td class="py-2 px-2 border-b border-r border-gray-300">
-            <input type="text" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+            <input type="text" name="servicePart[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
           </td>
           <td class="py-2 px-2 border-b border-r border-gray-300">
-            <input type="text" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+            <input type="text" name="serviceDesc[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
           </td>
           <td class="py-2 px-2 border-b border-gray-300 text-center">
             <button class="text-red-500 hover:text-red-700 transition-colors" onclick="removeRow(this)">
@@ -62,13 +62,13 @@
     const newRow = document.createElement('tr');
     newRow.innerHTML = `
       <td class="py-2 px-2 border-b border-r border-gray-300">
-        <input type="text" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+        <input type="text" name="serviceQuantity[]" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
       </td>
       <td class="py-2 px-2 border-b border-r border-gray-300">
-        <input type="text" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+        <input type="text" name="servicePart[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
       </td>
       <td class="py-2 px-2 border-b border-r border-gray-300">
-        <input type="text" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+        <input type="text" name="serviceDesc[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
       </td>
       <td class="py-2 px-2 border-b border-gray-300 text-center">
         <button class="text-red-500 hover:text-red-700 transition-colors" onclick="removeRow(this)">✖</button>

--- a/jsp/checklist/aireCondicionado/SignatureSection.jsp
+++ b/jsp/checklist/aireCondicionado/SignatureSection.jsp
@@ -9,7 +9,7 @@
 
     <div class="mb-4">
       <label class="block text-sm font-medium text-gray-700 mb-1">Nombre completo:</label>
-      <input type="text" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" />
+      <input type="text" name="technicianName" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" />
     </div>
 
     <div>
@@ -32,7 +32,7 @@
 
     <div class="mb-4">
       <label class="block text-sm font-medium text-gray-700 mb-1">Nombre completo:</label>
-      <input type="text" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" />
+      <input type="text" name="managerName" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" />
     </div>
 
     <div>

--- a/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
@@ -1,5 +1,8 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ page import="java.util.*" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<c:set var="base" value="${fn:replace(param.title,' ','_')}" />
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
 <div>
@@ -11,25 +14,25 @@
       <tr>
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
@@ -1,4 +1,7 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<c:set var="base" value="${fn:replace(param.title,' ','_')}" />
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
 <div>
@@ -12,7 +15,7 @@
           Medición de presión (colocar valor psi) ALTA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
@@ -20,7 +23,7 @@
           Medición de presión (colocar valor psi) BAJA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/refrigeracion/Header.jsp
+++ b/jsp/checklist/refrigeracion/Header.jsp
@@ -33,17 +33,17 @@
       <div class="col-span-2">
         <div class="mb-4">
           <label class="block text-sm font-semibold text-gray-700">Cliente</label>
-          <input type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+          <input type="text" name="cliente" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
         </div>
 
         <div class="grid grid-cols-2 gap-4">
           <div>
             <label class="block text-sm font-semibold text-gray-700">Área</label>
-            <input type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="text" name="area" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
           </div>
           <div>
             <label class="block text-sm font-semibold text-gray-700">Plaza</label>
-            <input type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="text" name="plaza" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
           </div>
         </div>
       </div>
@@ -51,17 +51,17 @@
       <div>
         <div class="mb-4">
           <label class="block text-sm font-semibold text-gray-700">Unidad</label>
-          <input type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+          <input type="text" name="unidad" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
         </div>
 
         <div class="grid grid-cols-2 gap-4">
           <div>
             <label class="block text-sm font-semibold text-gray-700">Fecha</label>
-            <input type="date" id="fecha" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="date" id="fecha" name="fecha" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
           </div>
           <div>
             <label class="block text-sm font-semibold text-gray-700">Hora de Entrada</label>
-            <input type="time" id="hora" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="time" id="hora" name="horaEntrada" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
           </div>
         </div>
       </div>

--- a/jsp/checklist/refrigeracion/OperationReadings.jsp
+++ b/jsp/checklist/refrigeracion/OperationReadings.jsp
@@ -11,33 +11,33 @@
         <tbody>
           <tr>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_voltage_ab" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_voltage_bc" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_voltage_ca" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
           </tr>
           <tr class="bg-gray-50">
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_amp_a" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_amp_b" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_amp_c" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
           </tr>
           <tr>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Superheat compresor</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_superheat" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Temp. Inyeccion</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_temp_inyeccion" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
           </tr>
           <tr class="bg-gray-50">
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Temp. Succion</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_temp_succion" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Temp. Retorno</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_temp_retorno" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
           </tr>
           <tr>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Medicion de presion (ALTA)    PSI</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Medicion de presion (BAJA)    PSI</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
           </tr>
         </tbody>
       </table>
@@ -51,33 +51,33 @@
         <tbody>
           <tr>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_voltage_ab" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_voltage_bc" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_voltage_ca" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
           </tr>
           <tr class="bg-gray-50">
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_amp_a" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_amp_b" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_amp_c" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
           </tr>
           <tr>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Superheat compresor</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_superheat" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Temp. Inyeccion</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_temp_inyeccion" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
           </tr>
           <tr class="bg-gray-50">
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Temp. Succion</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_temp_succion" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Temp. Retorno</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_temp_retorno" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
           </tr>
           <tr>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Medicion de presion (ALTA)    PSI</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Medicion de presion (BAJA)    PSI</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
           </tr>
         </tbody>
       </table>

--- a/jsp/checklist/refrigeracion/ServicesSection.jsp
+++ b/jsp/checklist/refrigeracion/ServicesSection.jsp
@@ -27,13 +27,13 @@
       <tbody id="servicesBody">
         <tr>
           <td class="py-2 px-2 border-b border-r border-gray-300">
-            <input type="text" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+            <input type="text" name="serviceQuantity[]" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
           </td>
           <td class="py-2 px-2 border-b border-r border-gray-300">
-            <input type="text" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+            <input type="text" name="servicePart[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
           </td>
           <td class="py-2 px-2 border-b border-r border-gray-300">
-            <input type="text" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+            <input type="text" name="serviceDesc[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
           </td>
           <td class="py-2 px-2 border-b border-gray-300 text-center">
             <button class="text-red-500 hover:text-red-700 transition-colors" onclick="removeRow(this)">
@@ -62,13 +62,13 @@
     const newRow = document.createElement('tr');
     newRow.innerHTML = `
       <td class="py-2 px-2 border-b border-r border-gray-300">
-        <input type="text" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+        <input type="text" name="serviceQuantity[]" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
       </td>
       <td class="py-2 px-2 border-b border-r border-gray-300">
-        <input type="text" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+        <input type="text" name="servicePart[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
       </td>
       <td class="py-2 px-2 border-b border-r border-gray-300">
-        <input type="text" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+        <input type="text" name="serviceDesc[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
       </td>
       <td class="py-2 px-2 border-b border-gray-300 text-center">
         <button class="text-red-500 hover:text-red-700 transition-colors" onclick="removeRow(this)">✖</button>

--- a/jsp/checklist/refrigeracion/SignatureSection.jsp
+++ b/jsp/checklist/refrigeracion/SignatureSection.jsp
@@ -9,7 +9,7 @@
 
     <div class="mb-4">
       <label class="block text-sm font-medium text-gray-700 mb-1">Nombre completo:</label>
-      <input type="text" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" />
+      <input type="text" name="technicianName" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" />
     </div>
 
     <div>
@@ -32,7 +32,7 @@
 
     <div class="mb-4">
       <label class="block text-sm font-medium text-gray-700 mb-1">Nombre completo:</label>
-      <input type="text" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" />
+      <input type="text" name="managerName" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" />
     </div>
 
     <div>

--- a/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
@@ -1,5 +1,8 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ page import="java.util.*" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<c:set var="base" value="${fn:replace(param.title,' ','_')}" />
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
 <div>
@@ -11,25 +14,25 @@
       <tr>
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
@@ -1,4 +1,7 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<c:set var="base" value="${fn:replace(param.title,' ','_')}" />
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
 <div>
@@ -12,7 +15,7 @@
           Medición de presión (colocar valor psi) ALTA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
@@ -20,7 +23,7 @@
           Medición de presión (colocar valor psi) BAJA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Summary
- add missing name attributes in maintenance headers
- wire up dynamic operation blocks with base param names
- attach names to pressure blocks
- persist services tables and signature sections with form names
- capture refrigeration readings with field identifiers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b4ccc4fe083329d419f28e6c04937