### PR TITLE
Add order service field to checklist headers

### DIFF
--- a/jsp/checklist/aireCondicionado/Header.jsp
+++ b/jsp/checklist/aireCondicionado/Header.jsp
@@ -49,9 +49,15 @@
       </div>
 
       <div>
-        <div class="mb-4">
-          <label class="block text-sm font-semibold text-gray-700">Unidad</label>
-            <input type="text" name="unidad" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+        <div class="grid grid-cols-2 gap-4 mb-4">
+          <div>
+            <label class="block text-sm font-semibold text-gray-700">Unidad</label>
+              <input type="text" name="unidad" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+          </div>
+          <div>
+            <label class="block text-sm font-semibold text-gray-700">Orden de servicio</label>
+              <input type="text" id="ordenServicio" name="ordenServicio" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="<%= request.getParameter("orden") != null ? request.getParameter("orden") : "" %>" />
+          </div>
         </div>
 
         <div class="grid grid-cols-2 gap-4">

--- a/jsp/checklist/refrigeracion/Header.jsp
+++ b/jsp/checklist/refrigeracion/Header.jsp
@@ -49,9 +49,15 @@
       </div>
 
       <div>
-        <div class="mb-4">
-          <label class="block text-sm font-semibold text-gray-700">Unidad</label>
-          <input type="text" name="unidad" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+        <div class="grid grid-cols-2 gap-4 mb-4">
+          <div>
+            <label class="block text-sm font-semibold text-gray-700">Unidad</label>
+            <input type="text" name="unidad" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+          </div>
+          <div>
+            <label class="block text-sm font-semibold text-gray-700">Orden de servicio</label>
+            <input type="text" id="ordenServicio" name="ordenServicio" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="<%= request.getParameter("orden") != null ? request.getParameter("orden") : "" %>" />
+          </div>
         </div>
 
         <div class="grid grid-cols-2 gap-4">

--- a/jsp/formulario.jsp
+++ b/jsp/formulario.jsp
@@ -60,7 +60,7 @@
 <!-- 	 </div> -->
 <!-- 	 <div id="sec-frmultimotec" class="form-group"> -->
 	 <div class="col-xs-2">Fecha &Uacute;ltima Atenci&oacute;n:</div>
-	<div class="col-xs-4"><input disabled type="text" id="frmultimotec" style="width:100%;" class="form-control"  placeholder="Fecha de última atención"/></div>
+	<div class="col-xs-4"><input disabled type="text" id="frmultimotec" style="width:100%;" class="form-control"  placeholder="Fecha de Ãºltima atenciÃ³n"/></div>
 <!-- 	</div> -->
 </div>
 </div>
@@ -131,7 +131,7 @@
 	 </select>
 	</div>
 	<div class="col-xs-2">Domicilio:</div>
-	<div class="col-xs-4"><input type="text" id="frmdireccion" style="width:100%;" class="form-control"  placeholder="nombre de la dirección"/></div>
+	<div class="col-xs-4"><input type="text" id="frmdireccion" style="width:100%;" class="form-control"  placeholder="nombre de la direcciÃ³n"/></div>
 	
 	
 	
@@ -207,7 +207,7 @@
 	<div class="col-xs-2">Otro:</div>
 	<div class="col-xs-10">
 
-		<input type="text" id="razonservotro" style="width:100%; margin-top: 5px;" class="form-control"  placeholder="Describir razón del servicio"/>
+		<input type="text" id="razonservotro" style="width:100%; margin-top: 5px;" class="form-control"  placeholder="Describir razÃ³n del servicio"/>
 	</div>
 
 </div>
@@ -591,6 +591,16 @@
 		});
 	 }
 	
+function abrirFormatoAire() {
+    var orden = $("#frmordenServicio").val();
+    window.open("maintenance-form?orden=" + encodeURIComponent(orden), "_blank");
+}
+
+function abrirFormatoRefrigeracion() {
+    var orden = $("#frmordenServicio").val();
+    window.open("refrigeracion-form?orden=" + encodeURIComponent(orden), "_blank");
+}
+
 // });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- include new "Orden de servicio" input next to Unidad on both maintenance headers
- autopopulate the input using the `orden` request parameter
- open checklists from `formulario.jsp` with the order as a query parameter

## Testing
- `python3 wscript.py -h`


------
https://chatgpt.com/codex/tasks/task_e_68747abae2008332aa1f9bd2e2a2bc4f