### PR TITLE
Propagate order details to maintenance forms and persist order number

### DIFF
--- a/jsp/formTerminar.jsp
+++ b/jsp/formTerminar.jsp
@@ -296,8 +296,8 @@
     <li><a href="#" id="tabRefrigeracionLink">Refrigeracion</a></li>
   </ul>
   <div class="tab-content">
-    <iframe id="tabAire" class="maintTab" src="MaintenanceForm.jsp" style="width:100%; border:0; height:800px;"></iframe>
-    <iframe id="tabRefrigeracion" class="maintTab" src="MaintenanceFormRefrigeracion.jsp" style="width:100%; border:0; height:800px; display:none;"></iframe>
+    <iframe id="tabAire" class="maintTab" style="width:100%; border:0; height:800px;"></iframe>
+    <iframe id="tabRefrigeracion" class="maintTab" style="width:100%; border:0; height:800px; display:none;"></iframe>
   </div>
 </div>
 
@@ -310,6 +310,11 @@
                         if($('#frmtipomantenimiento').val() === 'PREVENTIVO'){
                                 $('#formtecnico').hide();
                                 $('#maintenanceTabs').show();
+                                $('#loadingfrm').css('height','60%');
+                                var orden = encodeURIComponent($('#frmordenServicio').val());
+                                var cliente = encodeURIComponent($('#frmcliente').val());
+                                $('#tabAire').attr('src', '../maintenance-form?orden=' + orden + '&cliente=' + cliente);
+                                $('#tabRefrigeracion').attr('src', '../refrigeracion-form?orden=' + orden + '&cliente=' + cliente);
                         }
 
                         $('#tabAireLink').on('click', function(e){

--- a/src/servlet/MaintenanceDataServlet.java
+++ b/src/servlet/MaintenanceDataServlet.java
@@ -41,10 +41,13 @@ public class MaintenanceDataServlet extends HttpServlet {
             }
         }
 
+        String ordenServicio = request.getParameter("ordenServicio");
+
         try (Connection conn = dataSource.getConnection();
                 PreparedStatement stmt = conn.prepareStatement(
-                        "INSERT INTO airecondicionado_data (data) VALUES (?)")) {
-            stmt.setString(1, json.toString());
+                        "INSERT INTO airecondicionado_data (orden_servicio, data) VALUES (?, ?)")) {
+            stmt.setString(1, ordenServicio);
+            stmt.setString(2, json.toString());
             stmt.executeUpdate();
         } catch (SQLException e) {
             throw new ServletException("Unable to save maintenance data", e);

--- a/src/servlet/RefrigeracionDataServlet.java
+++ b/src/servlet/RefrigeracionDataServlet.java
@@ -41,10 +41,13 @@ public class RefrigeracionDataServlet extends HttpServlet {
             }
         }
 
+        String ordenServicio = request.getParameter("ordenServicio");
+
         try (Connection conn = dataSource.getConnection();
                 PreparedStatement stmt = conn.prepareStatement(
-                        "INSERT INTO refrigeracion_data (data) VALUES (?)")) {
-            stmt.setString(1, json.toString());
+                        "INSERT INTO refrigeracion_data (orden_servicio, data) VALUES (?, ?)")) {
+            stmt.setString(1, ordenServicio);
+            stmt.setString(2, json.toString());
             stmt.executeUpdate();
         } catch (SQLException e) {
             throw new ServletException("Unable to save refrigeration data", e);


### PR DESCRIPTION
## Summary
- Populate maintenance form iframes with order and client values when finishing preventive orders
- Save `orden_servicio` separately in `airecondicionado_data` and `refrigeracion_data`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `mvn -q test` *(fails: Missing POM)*

------
https://chatgpt.com/codex/tasks/task_e_6896651920d483329f21600b97a730d1