### PR TITLE
Propagate order details to maintenance forms and persist order number

### DIFF
--- a/jsp/MaintenanceForm.jsp
+++ b/jsp/MaintenanceForm.jsp
@@ -15,7 +15,7 @@
 </head>
 <body>
 
-<form method="post" action="maintenance-form/save">
+<form id="maintenanceForm" method="post" action="maintenance-form/save">
 <div class="container mx-auto">
     <%-- Static header --%>
     <jsp:include page="checklist/aireCondicionado/Header.jsp" />
@@ -34,21 +34,21 @@
     <jsp:include page="checklist/aireCondicionado/ServicesSection.jsp" />
     <jsp:include page="checklist/aireCondicionado/SignatureSection.jsp" />
 
-    <div id="successAlert" class="text-center text-white bg-[#005c9b] p-4 rounded-md mb-4" style="display:none;">
-        Checklist guardado exitosamente
-    </div>
     <div class="my-4 text-center">
-        <button type="submit" id="saveButton" class="btn btn-primary" disabled>Guardar</button>
+        <button type="submit" id="saveButton" class="btn btn-primary">Guardar</button>
     </div>
 
 </div>
 </form>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-    const saveButton = document.getElementById('saveButton');
-    const alertBox = document.getElementById('successAlert');
-    saveButton.addEventListener('click', function () {
-        alertBox.style.display = 'block';
+    const form = document.getElementById('maintenanceForm');
+    form.addEventListener('submit', async function (e) {
+        e.preventDefault();
+        const formData = new FormData(form);
+        const resp = await fetch(form.action, { method: 'POST', body: formData });
+        const text = await resp.text();
+        alert(text);
     });
 });
 </script>

--- a/jsp/MaintenanceFormRefrigeracion.jsp
+++ b/jsp/MaintenanceFormRefrigeracion.jsp
@@ -15,7 +15,7 @@
 </head>
 <body>
 
-<form method="post" action="refrigeracion-form/save">
+<form id="refrigeracionForm" method="post" action="refrigeracion-form/save">
 <div class="container mx-auto">
     <%-- Static header --%>
     <jsp:include page="checklist/refrigeracion/Header.jsp" />
@@ -35,21 +35,21 @@
     <jsp:include page="checklist/refrigeracion/ServicesSection.jsp" />
     <jsp:include page="checklist/refrigeracion/SignatureSection.jsp" />
 
-    <div id="successAlert" class="text-center text-white bg-[#005c9b] p-4 rounded-md mb-4" style="display:none;">
-        Checklist guardado exitosamente
-    </div>
     <div class="my-4 text-center">
-        <button type="submit" id="saveButton" class="btn btn-primary" disabled>Guardar</button>
+        <button type="submit" id="saveButton" class="btn btn-primary">Guardar</button>
     </div>
 
 </div>
 </form>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-    const saveButton = document.getElementById('saveButton');
-    const alertBox = document.getElementById('successAlert');
-    saveButton.addEventListener('click', function () {
-        alertBox.style.display = 'block';
+    const form = document.getElementById('refrigeracionForm');
+    form.addEventListener('submit', async function (e) {
+        e.preventDefault();
+        const formData = new FormData(form);
+        const resp = await fetch(form.action, { method: 'POST', body: formData });
+        const text = await resp.text();
+        alert(text);
     });
 });
 </script>

--- a/jsp/formTerminar.jsp
+++ b/jsp/formTerminar.jsp
@@ -296,8 +296,8 @@
     <li><a href="#" id="tabRefrigeracionLink">Refrigeracion</a></li>
   </ul>
   <div class="tab-content">
-    <iframe id="tabAire" class="maintTab" src="MaintenanceForm.jsp" style="width:100%; border:0; height:800px;"></iframe>
-    <iframe id="tabRefrigeracion" class="maintTab" src="MaintenanceFormRefrigeracion.jsp" style="width:100%; border:0; height:800px; display:none;"></iframe>
+    <iframe id="tabAire" class="maintTab" style="width:100%; border:0; height:800px;"></iframe>
+    <iframe id="tabRefrigeracion" class="maintTab" style="width:100%; border:0; height:800px; display:none;"></iframe>
   </div>
 </div>
 
@@ -310,6 +310,11 @@
                         if($('#frmtipomantenimiento').val() === 'PREVENTIVO'){
                                 $('#formtecnico').hide();
                                 $('#maintenanceTabs').show();
+                                $('#loadingfrm').css('height','60%');
+                                var orden = encodeURIComponent($('#frmordenServicio').val());
+                                var cliente = encodeURIComponent($('#frmcliente').val());
+                                $('#tabAire').attr('src', '../maintenance-form?orden=' + orden + '&cliente=' + cliente);
+                                $('#tabRefrigeracion').attr('src', '../refrigeracion-form?orden=' + orden + '&cliente=' + cliente);
                         }
 
                         $('#tabAireLink').on('click', function(e){

--- a/src/servlet/MaintenanceDataServlet.java
+++ b/src/servlet/MaintenanceDataServlet.java
@@ -41,10 +41,13 @@ public class MaintenanceDataServlet extends HttpServlet {
             }
         }
 
+        String ordenServicio = request.getParameter("ordenServicio");
+
         try (Connection conn = dataSource.getConnection();
                 PreparedStatement stmt = conn.prepareStatement(
-                        "INSERT INTO airecondicionado_data (data) VALUES (?)")) {
-            stmt.setString(1, json.toString());
+                        "INSERT INTO airecondicionado_data (orden_servicio, data) VALUES (?, ?)")) {
+            stmt.setString(1, ordenServicio);
+            stmt.setString(2, json.toString());
             stmt.executeUpdate();
         } catch (SQLException e) {
             throw new ServletException("Unable to save maintenance data", e);

--- a/src/servlet/RefrigeracionDataServlet.java
+++ b/src/servlet/RefrigeracionDataServlet.java
@@ -41,10 +41,13 @@ public class RefrigeracionDataServlet extends HttpServlet {
             }
         }
 
+        String ordenServicio = request.getParameter("ordenServicio");
+
         try (Connection conn = dataSource.getConnection();
                 PreparedStatement stmt = conn.prepareStatement(
-                        "INSERT INTO refrigeracion_data (data) VALUES (?)")) {
-            stmt.setString(1, json.toString());
+                        "INSERT INTO refrigeracion_data (orden_servicio, data) VALUES (?, ?)")) {
+            stmt.setString(1, ordenServicio);
+            stmt.setString(2, json.toString());
             stmt.executeUpdate();
         } catch (SQLException e) {
             throw new ServletException("Unable to save refrigeration data", e);


### PR DESCRIPTION
## Summary
- Populate maintenance form iframes with order and client values when finishing preventive orders
- Save `orden_servicio` separately in `airecondicionado_data` and `refrigeracion_data`
- Allow maintenance and refrigeration checklists to be saved without additional field input

## Testing
- `npm test` *(fails: Could not read package.json)*
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896651920d483329f21600b97a730d1