### PR TITLE
fix: avoid template literals in maintenance forms

### DIFF
--- a/jsp/MaintenanceForm.jsp
+++ b/jsp/MaintenanceForm.jsp
@@ -46,7 +46,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     const ordenInput = document.getElementById('ordenServicio');
     if (ordenInput && ordenInput.value) {
         try {
-            const resp = await fetch(`maintenance-form/save?ordenServicio=${encodeURIComponent(ordenInput.value)}`);
+            const resp = await fetch('maintenance-form/save?ordenServicio=' + encodeURIComponent(ordenInput.value));
             if (resp.ok) {
                 const data = await resp.json();
                 Object.entries(data).forEach(([key, value]) => {

--- a/jsp/MaintenanceFormRefrigeracion.jsp
+++ b/jsp/MaintenanceFormRefrigeracion.jsp
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     const ordenInput = document.getElementById('ordenServicio');
     if (ordenInput && ordenInput.value) {
         try {
-            const resp = await fetch(`refrigeracion-form/save?ordenServicio=${encodeURIComponent(ordenInput.value)}`);
+            const resp = await fetch('refrigeracion-form/save?ordenServicio=' + encodeURIComponent(ordenInput.value));
             if (resp.ok) {
                 const data = await resp.json();
                 Object.entries(data).forEach(([key, value]) => {


### PR DESCRIPTION
## Summary
- replace template literals with string concatenation for service order fetch requests in maintenance forms

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689685fa63008332a20a07ac4aee9137