### PR TITLE
Disable save until checklist signatures provided

### DIFF
--- a/jsp/MaintenanceForm.jsp
+++ b/jsp/MaintenanceForm.jsp
@@ -35,7 +35,7 @@
     <jsp:include page="checklist/aireCondicionado/SignatureSection.jsp" />
 
     <div class="my-4 text-center">
-        <button type="submit" id="saveButton" class="btn btn-primary">Guardar</button>
+        <button type="submit" id="saveButton" class="btn btn-primary" disabled>Guardar</button>
     </div>
 
 </div>

--- a/jsp/MaintenanceFormRefrigeracion.jsp
+++ b/jsp/MaintenanceFormRefrigeracion.jsp
@@ -36,7 +36,7 @@
     <jsp:include page="checklist/refrigeracion/SignatureSection.jsp" />
 
     <div class="my-4 text-center">
-        <button type="submit" id="saveButton" class="btn btn-primary">Guardar</button>
+        <button type="submit" id="saveButton" class="btn btn-primary" disabled>Guardar</button>
     </div>
 
 </div>

--- a/jsp/checklist/aireCondicionado/SignatureSection.jsp
+++ b/jsp/checklist/aireCondicionado/SignatureSection.jsp
@@ -111,11 +111,13 @@
     checkFormValidity();
   }
 
-  window.onload = function() {
+  document.addEventListener('DOMContentLoaded', function() {
     initSignatureCanvas('techCanvas');
     initSignatureCanvas('managerCanvas');
 
     document.querySelector('input[name="technicianName"]').addEventListener('input', checkFormValidity);
     document.querySelector('input[name="managerName"]').addEventListener('input', checkFormValidity);
-  };
+
+    checkFormValidity();
+  });
 </script>

--- a/jsp/checklist/refrigeracion/SignatureSection.jsp
+++ b/jsp/checklist/refrigeracion/SignatureSection.jsp
@@ -111,11 +111,13 @@
     checkFormValidity();
   }
 
-  window.onload = function() {
+  document.addEventListener('DOMContentLoaded', function() {
     initSignatureCanvas('techCanvas');
     initSignatureCanvas('managerCanvas');
 
     document.querySelector('input[name="technicianName"]').addEventListener('input', checkFormValidity);
     document.querySelector('input[name="managerName"]').addEventListener('input', checkFormValidity);
-  };
+
+    checkFormValidity();
+  });
 </script>


### PR DESCRIPTION
## Summary
- Disable Guardar button by default in maintenance forms
- Initialize signature validation on DOM load to enable saving only after technician and manager names and signatures are supplied

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a2cc4577c8332bde64698d98e1a56