### PR TITLE
Support multipart form data for maintenance and refrigeration servlets

### DIFF
--- a/src/servlet/MaintenanceDataServlet.java
+++ b/src/servlet/MaintenanceDataServlet.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import javax.annotation.Resource;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
+import javax.servlet.annotation.MultipartConfig;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -21,6 +22,7 @@ import org.json.JSONObject;
  */
 @SuppressWarnings("serial")
 @WebServlet("/maintenance-form/save")
+@MultipartConfig
 public class MaintenanceDataServlet extends HttpServlet {
 
     @Resource(name = "jdbc/coolService")
@@ -57,6 +59,11 @@ public class MaintenanceDataServlet extends HttpServlet {
                 }
             }
             ordenServicio = request.getParameter("ordenServicio");
+        }
+
+        if (ordenServicio == null || ordenServicio.isEmpty()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing ordenServicio");
+            return;
         }
 
         json.remove("ordenServicio");

--- a/src/servlet/RefrigeracionDataServlet.java
+++ b/src/servlet/RefrigeracionDataServlet.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import javax.annotation.Resource;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
+import javax.servlet.annotation.MultipartConfig;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -21,6 +22,7 @@ import org.json.JSONObject;
  */
 @SuppressWarnings("serial")
 @WebServlet("/refrigeracion-form/save")
+@MultipartConfig
 public class RefrigeracionDataServlet extends HttpServlet {
 
     @Resource(name = "jdbc/coolService")
@@ -57,6 +59,11 @@ public class RefrigeracionDataServlet extends HttpServlet {
                 }
             }
             ordenServicio = request.getParameter("ordenServicio");
+        }
+
+        if (ordenServicio == null || ordenServicio.isEmpty()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing ordenServicio");
+            return;
         }
 
         json.remove("ordenServicio");


### PR DESCRIPTION
## Summary
- Enable multipart/form-data parsing in MaintenanceDataServlet and RefrigeracionDataServlet using `@MultipartConfig`
- Guard against missing `ordenServicio` by returning `400 Bad Request`

## Testing
- `javac src/servlet/MaintenanceDataServlet.java src/servlet/RefrigeracionDataServlet.java` *(fails: package javax.servlet does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689a35a8611483328826a4a1aefd122e