### PR TITLE
Load saved maintenance data into JSP forms

### DIFF
--- a/jsp/checklist/aireCondicionado/ChecklistSection.jsp
+++ b/jsp/checklist/aireCondicionado/ChecklistSection.jsp
@@ -1,4 +1,5 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
@@ -19,6 +20,7 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
+            <c:set var="inputName" value="${fn:replace(fn:concat(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), '-Bien'), ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
@@ -26,7 +28,7 @@
               <td class="py-2 px-2 border-b border-r border-gray-300 text-center">
                 <div class="flex justify-center space-x-4">
                   <label class="inline-flex items-center">
-                    <input type="radio" name="status-${sectionTitle}-${status.index}-Bien" class="form-radio h-4 w-4 text-[#005c9b]" />
+                    <input type="radio" name="${inputName}" value="B" class="form-radio h-4 w-4 text-[#005c9b]" <c:if test="${savedData[inputName] eq 'B'}">checked</c:if>/>
                     <span class="ml-1 text-sm text-gray-700">B</span>
                   </label>
                 </div>
@@ -34,7 +36,7 @@
               <td class="py-2 px-2 border-b border-gray-300 text-center">
                 <div class="flex justify-center space-x-4">
                   <label class="inline-flex items-center">
-                    <input type="radio" name="status-${sectionTitle}-${status.index}-Bien" class="form-radio h-4 w-4 text-red-600" />
+                    <input type="radio" name="${inputName}" value="M" class="form-radio h-4 w-4 text-red-600" <c:if test="${savedData[inputName] eq 'M'}">checked</c:if>/>
                     <span class="ml-1 text-sm text-gray-700">M</span>
                   </label>
                 </div>
@@ -51,25 +53,26 @@
             <th class="py-2 px-2 border-b border-r border-gray-300 text-center text-sm font-medium text-gray-700">Juegos</th>
             <th class="py-2 px-2 border-b border-r border-gray-300 text-center text-sm font-medium text-gray-700">Comedor</th>
             <th class="py-2 px-2 border-b border-r border-gray-300 text-center text-sm font-medium text-gray-700">Cocina</th>
-            <th class="py-2 px-2 border-b border-gray-300 text-center text-sm font-medium text-gray-700">Baños</th>
+            <th class="py-2 px-2 border-b border-gray-300 text-center text-sm font-medium text-gray-700">Baos</th>
           </tr>
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
+            <c:set var="nameBase" value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
               </td>
-
-              <c:forEach var="zone" items="${['Juegos', 'Comedor', 'Cocina', 'Baños']}">
+              <c:forEach var="zone" items="${['Juegos', 'Comedor', 'Cocina', 'Baos']}">
+                <c:set var="inputName" value="${fn:replace(fn:concat(nameBase, fn:concat('-', zone)), ' ', '_')}" />
                 <td class="py-2 px-2 border-b border-r border-gray-300 text-center">
                   <div class="flex justify-center space-x-4">
                     <label class="inline-flex items-center">
-                      <input type="radio" name="status-${sectionTitle}-${status.index}-${zone}" class="form-radio h-4 w-4 text-[#005c9b]" />
+                      <input type="radio" name="${inputName}" value="B" class="form-radio h-4 w-4 text-[#005c9b]" <c:if test="${savedData[inputName] eq 'B'}">checked</c:if>/>
                       <span class="ml-1 text-sm text-gray-700">B</span>
                     </label>
                     <label class="inline-flex items-center">
-                      <input type="radio" name="status-${sectionTitle}-${status.index}-${zone}" class="form-radio h-4 w-4 text-red-600" />
+                      <input type="radio" name="${inputName}" value="M" class="form-radio h-4 w-4 text-red-600" <c:if test="${savedData[inputName] eq 'M'}">checked</c:if>/>
                       <span class="ml-1 text-sm text-gray-700">M</span>
                     </label>
                   </div>

--- a/jsp/checklist/aireCondicionado/Header.jsp
+++ b/jsp/checklist/aireCondicionado/Header.jsp
@@ -1,4 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
@@ -32,18 +33,18 @@
     <div class="grid grid-cols-3 gap-4 mb-6">
       <div class="col-span-2">
         <div class="mb-4">
-          <label class="block text-sm font-semibold text-gray-700">Cliente</label>          
-          <input type="text" id="cliente" name="cliente" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="<%= request.getParameter("cliente") != null ? request.getParameter("cliente") : "" %>" />
+          <label class="block text-sm font-semibold text-gray-700">Cliente</label>
+          <input type="text" id="cliente" name="cliente" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.cliente ? savedData.cliente : (not empty param.cliente ? param.cliente : '')}" />
         </div>
 
         <div class="grid grid-cols-2 gap-4">
           <div>
             <label class="block text-sm font-semibold text-gray-700">Área</label>
-              <input type="text" name="area" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="text" name="area" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.area ? savedData.area : ''}" />
           </div>
           <div>
             <label class="block text-sm font-semibold text-gray-700">Plaza</label>
-              <input type="text" name="plaza" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="text" name="plaza" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.plaza ? savedData.plaza : ''}" />
           </div>
         </div>
       </div>
@@ -52,22 +53,22 @@
         <div class="grid grid-cols-2 gap-4 mb-4">
           <div>
             <label class="block text-sm font-semibold text-gray-700">Unidad</label>
-              <input type="text" name="unidad" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="text" name="unidad" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.unidad ? savedData.unidad : ''}" />
           </div>
           <div>
             <label class="block text-sm font-semibold text-gray-700">Orden de servicio</label>
-              <input type="text" id="ordenServicio" name="ordenServicio" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="<%= request.getParameter("ordenServicio") != null ? request.getParameter("ordenServicio") : (request.getParameter("orden") != null ? request.getParameter("orden") : "") %>" />
+              <input type="text" id="ordenServicio" name="ordenServicio" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.ordenServicio ? savedData.ordenServicio : (not empty param.ordenServicio ? param.ordenServicio : (not empty param.orden ? param.orden : ''))}" />
           </div>
         </div>
 
         <div class="grid grid-cols-2 gap-4">
           <div>
             <label class="block text-sm font-semibold text-gray-700">Fecha</label>
-              <input type="date" id="fecha" name="fecha" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="date" id="fecha" name="fecha" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.fecha ? savedData.fecha : ''}" />
           </div>
           <div>
             <label class="block text-sm font-semibold text-gray-700">Hora de Entrada</label>
-              <input type="time" id="hora" name="horaEntrada" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="time" id="hora" name="horaEntrada" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.horaEntrada ? savedData.horaEntrada : ''}" />
           </div>
         </div>
       </div>
@@ -77,8 +78,14 @@
 
 <script>
   window.addEventListener('DOMContentLoaded', () => {
+    const fechaInput = document.getElementById('fecha');
+    const horaInput = document.getElementById('hora');
     const today = new Date();
-    document.getElementById('fecha').value = today.toISOString().split('T')[0];
-    document.getElementById('hora').value = today.toTimeString().substring(0, 5);
+    if (!fechaInput.value) {
+      fechaInput.value = today.toISOString().split('T')[0];
+    }
+    if (!horaInput.value) {
+      horaInput.value = today.toTimeString().substring(0, 5);
+    }
   });
 </script>

--- a/jsp/checklist/aireCondicionado/ServicesSection.jsp
+++ b/jsp/checklist/aireCondicionado/ServicesSection.jsp
@@ -1,4 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
 <div class="mb-8">
@@ -25,22 +26,49 @@
         </tr>
       </thead>
       <tbody id="servicesBody">
-        <tr>
-          <td class="py-2 px-2 border-b border-r border-gray-300">
-            <input type="text" name="serviceQuantity[]" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
-          </td>
-          <td class="py-2 px-2 border-b border-r border-gray-300">
-            <input type="text" name="servicePart[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
-          </td>
-          <td class="py-2 px-2 border-b border-r border-gray-300">
-            <input type="text" name="serviceDesc[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
-          </td>
-          <td class="py-2 px-2 border-b border-gray-300 text-center">
-            <button class="text-red-500 hover:text-red-700 transition-colors" onclick="removeRow(this)">
-              ✖
-            </button>
-          </td>
-        </tr>
+        <c:choose>
+          <c:when test="${not empty savedData['serviceQuantity[]']}">
+            <c:set var="quantities" value="${savedData['serviceQuantity[]']}" />
+            <c:set var="parts" value="${savedData['servicePart[]']}" />
+            <c:set var="descs" value="${savedData['serviceDesc[]']}" />
+            <c:forEach var="qty" items="${quantities}" varStatus="i">
+              <tr>
+                <td class="py-2 px-2 border-b border-r border-gray-300">
+                  <input type="text" name="serviceQuantity[]" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" value="${qty}" />
+                </td>
+                <td class="py-2 px-2 border-b border-r border-gray-300">
+                  <input type="text" name="servicePart[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" value="${parts[i.index]}" />
+                </td>
+                <td class="py-2 px-2 border-b border-r border-gray-300">
+                  <input type="text" name="serviceDesc[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" value="${descs[i.index]}" />
+                </td>
+                <td class="py-2 px-2 border-b border-gray-300 text-center">
+                  <button class="text-red-500 hover:text-red-700 transition-colors" onclick="removeRow(this)">
+                    ✖
+                  </button>
+                </td>
+              </tr>
+            </c:forEach>
+          </c:when>
+          <c:otherwise>
+            <tr>
+              <td class="py-2 px-2 border-b border-r border-gray-300">
+                <input type="text" name="serviceQuantity[]" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+              </td>
+              <td class="py-2 px-2 border-b border-r border-gray-300">
+                <input type="text" name="servicePart[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+              </td>
+              <td class="py-2 px-2 border-b border-r border-gray-300">
+                <input type="text" name="serviceDesc[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+              </td>
+              <td class="py-2 px-2 border-b border-gray-300 text-center">
+                <button class="text-red-500 hover:text-red-700 transition-colors" onclick="removeRow(this)">
+                  ✖
+                </button>
+              </td>
+            </tr>
+          </c:otherwise>
+        </c:choose>
       </tbody>
     </table>
   </div>

--- a/jsp/checklist/aireCondicionado/SignatureSection.jsp
+++ b/jsp/checklist/aireCondicionado/SignatureSection.jsp
@@ -1,4 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
 <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -9,7 +10,7 @@
 
     <div class="mb-4">
       <label class="block text-sm font-medium text-gray-700 mb-1">Nombre completo:</label>
-      <input type="text" name="technicianName" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" />
+      <input type="text" name="technicianName" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" value="${savedData.technicianName}" />
     </div>
 
     <div>
@@ -31,8 +32,8 @@
     <h3 class="text-md font-bold text-gray-700 mb-4">Nombre y Firma del Gerente de Unidad</h3>
 
     <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Nombre completo:</label>
-      <input type="text" name="managerName" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" />
+        <label class="block text-sm font-medium text-gray-700 mb-1">Nombre completo:</label>
+        <input type="text" name="managerName" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" value="${savedData.managerName}" />
     </div>
 
     <div>

--- a/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
@@ -14,25 +14,25 @@
       <tr>
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+<input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_voltage_AB')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+<input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_voltage_BC')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+<input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_voltage_CA')]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+<input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_amp_A')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+<input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_amp_B')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+<input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_amp_C')]}"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
@@ -15,7 +15,7 @@
           Medición de presión (colocar valor psi) ALTA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_presion_alta')]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
@@ -23,7 +23,7 @@
           Medición de presión (colocar valor psi) BAJA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_presion_baja')]}"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/refrigeracion/ChecklistSection.jsp
+++ b/jsp/checklist/refrigeracion/ChecklistSection.jsp
@@ -1,4 +1,5 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
@@ -8,7 +9,6 @@
   </h2>
   <div class="overflow-x-auto">
     <table class="min-w-full border border-gray-300">
-
       <c:if test="${bienMalOnly}">
         <thead>
           <tr class="bg-gray-100">
@@ -17,18 +17,19 @@
             <th class="py-2 px-2 border-b border-gray-300 text-center text-sm font-medium text-gray-700">Mal</th>
           </tr>
         </thead>
-
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
+            <c:set var="baseName" value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
+            <c:set var="nameBien" value="${fn:concat(baseName,'-Bien')}" />
+            <c:set var="nameMal" value="${fn:concat(baseName,'-Mal')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
               </td>
-
               <td class="py-2 px-2 border-b border-r border-gray-300 text-center">
                 <div class="flex justify-center space-x-4">
                   <label class="inline-flex items-center">
-                    <input type="radio" name="status-${sectionTitle}-${status.index}-Bien" class="form-radio h-4 w-4 text-[#005c9b]" />
+                    <input type="radio" name="${nameBien}" value="B" class="form-radio h-4 w-4 text-[#005c9b]" <c:if test="${savedData[nameBien] eq 'B' || savedData[nameBien] eq 'on'}">checked</c:if>/>
                     <span class="ml-1 text-sm text-gray-700">B</span>
                   </label>
                 </div>
@@ -36,17 +37,16 @@
               <td class="py-2 px-2 border-b border-gray-300 text-center">
                 <div class="flex justify-center space-x-4">
                   <label class="inline-flex items-center">
-                    <input type="radio" name="status-${sectionTitle}-${status.index}-Mal" class="form-radio h-4 w-4 text-red-600" />
+                    <input type="radio" name="${nameBien}" value="M" class="form-radio h-4 w-4 text-red-600" <c:if test="${savedData[nameBien] eq 'M'}">checked</c:if>/>
                     <span class="ml-1 text-sm text-gray-700">M</span>
                   </label>
                 </div>
               </td>
-
             </tr>
           </c:forEach>
         </tbody>
       </c:if>
-    
+
       <c:if test="${!bienMalOnly}">
         <thead>
           <tr class="bg-gray-100">
@@ -57,36 +57,26 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
+            <c:set var="nameBase" value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
               </td>
-
-              <td class="py-2 px-2 border-b border-r border-gray-300 text-center">
-                <div class="flex justify-center space-x-4">
-                  <label class="inline-flex items-center">
-                    <input type="radio" name="status-${sectionTitle}-${status.index}-Conservacion" class="form-radio h-4 w-4 text-[#005c9b]" />
-                    <span class="ml-1 text-sm text-gray-700">B</span>
-                  </label>
-                  <label class="inline-flex items-center">
-                    <input type="radio" name="status-${sectionTitle}-${status.index}-Conservacion" class="form-radio h-4 w-4 text-red-600" />
-                    <span class="ml-1 text-sm text-gray-700">M</span>
-                  </label>
-                </div>
-              </td>
-              <td class="py-2 px-2 border-b border-gray-300 text-center">
-                <div class="flex justify-center space-x-4">
-                  <label class="inline-flex items-center">
-                    <input type="radio" name="status-${sectionTitle}-${status.index}-Freezer" class="form-radio h-4 w-4 text-[#005c9b]" />
-                    <span class="ml-1 text-sm text-gray-700">B</span>
-                  </label>
-                  <label class="inline-flex items-center">
-                    <input type="radio" name="status-${sectionTitle}-${status.index}-Freezer" class="form-radio h-4 w-4 text-red-600" />
-                    <span class="ml-1 text-sm text-gray-700">M</span>
-                  </label>
-                </div>
-              </td>
-
+              <c:forEach var="zone" items="${['Conservacion','Freezer']}">
+                <c:set var="inputName" value="${fn:replace(fn:concat(nameBase, fn:concat('-', zone)), ' ', '_')}" />
+                <td class="py-2 px-2 border-b border-r border-gray-300 text-center">
+                  <div class="flex justify-center space-x-4">
+                    <label class="inline-flex items-center">
+                      <input type="radio" name="${inputName}" value="B" class="form-radio h-4 w-4 text-[#005c9b]" <c:if test="${savedData[inputName] eq 'B' || savedData[inputName] eq 'on'}">checked</c:if>/>
+                      <span class="ml-1 text-sm text-gray-700">B</span>
+                    </label>
+                    <label class="inline-flex items-center">
+                      <input type="radio" name="${inputName}" value="M" class="form-radio h-4 w-4 text-red-600" <c:if test="${savedData[inputName] eq 'M'}">checked</c:if>/>
+                      <span class="ml-1 text-sm text-gray-700">M</span>
+                    </label>
+                  </div>
+                </td>
+              </c:forEach>
             </tr>
           </c:forEach>
         </tbody>

--- a/jsp/checklist/refrigeracion/Header.jsp
+++ b/jsp/checklist/refrigeracion/Header.jsp
@@ -1,4 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
@@ -33,17 +34,17 @@
       <div class="col-span-2">
         <div class="mb-4">
           <label class="block text-sm font-semibold text-gray-700">Cliente</label>
-          <input type="text" id="cliente" name="cliente" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="<%= request.getParameter("cliente") != null ? request.getParameter("cliente") : "" %>" />          
+          <input type="text" id="cliente" name="cliente" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.cliente ? savedData.cliente : (not empty param.cliente ? param.cliente : '')}" />
         </div>
 
         <div class="grid grid-cols-2 gap-4">
           <div>
             <label class="block text-sm font-semibold text-gray-700">Área</label>
-              <input type="text" name="area" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="text" name="area" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.area ? savedData.area : ''}" />
           </div>
           <div>
             <label class="block text-sm font-semibold text-gray-700">Plaza</label>
-              <input type="text" name="plaza" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="text" name="plaza" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.plaza ? savedData.plaza : ''}" />
           </div>
         </div>
       </div>
@@ -52,22 +53,22 @@
         <div class="grid grid-cols-2 gap-4 mb-4">
           <div>
             <label class="block text-sm font-semibold text-gray-700">Unidad</label>
-            <input type="text" name="unidad" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+            <input type="text" name="unidad" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.unidad ? savedData.unidad : ''}" />
           </div>
           <div>
             <label class="block text-sm font-semibold text-gray-700">Orden de servicio</label>
-            <input type="text" id="ordenServicio" name="ordenServicio" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="<%= request.getParameter("ordenServicio") != null ? request.getParameter("ordenServicio") : (request.getParameter("orden") != null ? request.getParameter("orden") : "") %>" />
+            <input type="text" id="ordenServicio" name="ordenServicio" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.ordenServicio ? savedData.ordenServicio : (not empty param.ordenServicio ? param.ordenServicio : (not empty param.orden ? param.orden : ''))}" />
           </div>
         </div>
 
         <div class="grid grid-cols-2 gap-4">
           <div>
             <label class="block text-sm font-semibold text-gray-700">Fecha</label>
-              <input type="date" id="fecha" name="fecha" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="date" id="fecha" name="fecha" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.fecha ? savedData.fecha : ''}" />
           </div>
           <div>
             <label class="block text-sm font-semibold text-gray-700">Hora de Entrada</label>
-              <input type="time" id="hora" name="horaEntrada" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" />
+              <input type="time" id="hora" name="horaEntrada" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#005c9b] focus:ring-[#005c9b] sm:text-sm" value="${not empty savedData.horaEntrada ? savedData.horaEntrada : ''}" />
           </div>
         </div>
       </div>
@@ -77,8 +78,14 @@
 
 <script>
   window.addEventListener('DOMContentLoaded', () => {
+    const fechaInput = document.getElementById('fecha');
+    const horaInput = document.getElementById('hora');
     const today = new Date();
-    document.getElementById('fecha').value = today.toISOString().split('T')[0];
-    document.getElementById('hora').value = today.toTimeString().substring(0, 5);
+    if (!fechaInput.value) {
+      fechaInput.value = today.toISOString().split('T')[0];
+    }
+    if (!horaInput.value) {
+      horaInput.value = today.toTimeString().substring(0, 5);
+    }
   });
 </script>

--- a/jsp/checklist/refrigeracion/ServicesSection.jsp
+++ b/jsp/checklist/refrigeracion/ServicesSection.jsp
@@ -1,4 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
 <div class="mb-8">
@@ -25,22 +26,45 @@
         </tr>
       </thead>
       <tbody id="servicesBody">
-        <tr>
-          <td class="py-2 px-2 border-b border-r border-gray-300">
-            <input type="text" name="serviceQuantity[]" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
-          </td>
-          <td class="py-2 px-2 border-b border-r border-gray-300">
-            <input type="text" name="servicePart[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
-          </td>
-          <td class="py-2 px-2 border-b border-r border-gray-300">
-            <input type="text" name="serviceDesc[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
-          </td>
-          <td class="py-2 px-2 border-b border-gray-300 text-center">
-            <button class="text-red-500 hover:text-red-700 transition-colors" onclick="removeRow(this)">
-              ✖
-            </button>
-          </td>
-        </tr>
+        <c:choose>
+          <c:when test="${not empty savedData['serviceQuantity[]']}">
+            <c:set var="quantities" value="${savedData['serviceQuantity[]']}" />
+            <c:set var="parts" value="${savedData['servicePart[]']}" />
+            <c:set var="descs" value="${savedData['serviceDesc[]']}" />
+            <c:forEach var="qty" items="${quantities}" varStatus="i">
+              <tr>
+                <td class="py-2 px-2 border-b border-r border-gray-300">
+                  <input type="text" name="serviceQuantity[]" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" value="${qty}" />
+                </td>
+                <td class="py-2 px-2 border-b border-r border-gray-300">
+                  <input type="text" name="servicePart[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" value="${parts[i.index]}" />
+                </td>
+                <td class="py-2 px-2 border-b border-r border-gray-300">
+                  <input type="text" name="serviceDesc[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" value="${descs[i.index]}" />
+                </td>
+                <td class="py-2 px-2 border-b border-gray-300 text-center">
+                  <button class="text-red-500 hover:text-red-700 transition-colors" onclick="removeRow(this)">✖</button>
+                </td>
+              </tr>
+            </c:forEach>
+          </c:when>
+          <c:otherwise>
+            <tr>
+              <td class="py-2 px-2 border-b border-r border-gray-300">
+                <input type="text" name="serviceQuantity[]" class="w-full text-center border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+              </td>
+              <td class="py-2 px-2 border-b border-r border-gray-300">
+                <input type="text" name="servicePart[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+              </td>
+              <td class="py-2 px-2 border-b border-r border-gray-300">
+                <input type="text" name="serviceDesc[]" class="w-full border-gray-300 rounded-sm focus:border-[#005c9b] focus:ring-[#005c9b]" />
+              </td>
+              <td class="py-2 px-2 border-b border-gray-300 text-center">
+                <button class="text-red-500 hover:text-red-700 transition-colors" onclick="removeRow(this)">✖</button>
+              </td>
+            </tr>
+          </c:otherwise>
+        </c:choose>
       </tbody>
     </table>
   </div>

--- a/jsp/checklist/refrigeracion/SignatureSection.jsp
+++ b/jsp/checklist/refrigeracion/SignatureSection.jsp
@@ -1,4 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
 <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -9,7 +10,7 @@
 
     <div class="mb-4">
       <label class="block text-sm font-medium text-gray-700 mb-1">Nombre completo:</label>
-      <input type="text" name="technicianName" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" />
+      <input type="text" name="technicianName" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" value="${savedData.technicianName}" />
     </div>
 
     <div>
@@ -32,7 +33,7 @@
 
     <div class="mb-4">
       <label class="block text-sm font-medium text-gray-700 mb-1">Nombre completo:</label>
-      <input type="text" name="managerName" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" />
+      <input type="text" name="managerName" class="w-full border-gray-300 rounded-md focus:border-blue-500 focus:ring-blue-500" value="${savedData.managerName}" />
     </div>
 
     <div>

--- a/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
@@ -14,25 +14,25 @@
       <tr>
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_voltage_AB')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_voltage_BC')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_voltage_CA')]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_amp_A')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_amp_B')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_amp_C')]}"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
@@ -15,7 +15,7 @@
           Medición de presión (colocar valor psi) ALTA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_presion_alta')]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
@@ -23,7 +23,7 @@
           Medición de presión (colocar valor psi) BAJA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/>
+          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_presion_baja')]}"/>
         </td>
       </tr>
     </tbody>

--- a/src/servlet/MaintenanceFormServlet.java
+++ b/src/servlet/MaintenanceFormServlet.java
@@ -1,14 +1,22 @@
 package servlet;
 
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Resource;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+
+import org.json.JSONObject;
 
 import clases.Activity;
 import clases.Section;
@@ -16,14 +24,57 @@ import clases.Section;
 @SuppressWarnings("serial")
 @WebServlet("/maintenance-form")
 public class MaintenanceFormServlet extends HttpServlet {
-   protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+   @Resource(name = "jdbc/coolService")
+   private DataSource dataSource;
+
+   @Override
+   protected void doGet(HttpServletRequest request, HttpServletResponse response)
+         throws ServletException, IOException {
       List<Section> sections = new ArrayList<>();
-      sections.add(new Section("ducteria", "DUCTERIA INTERNA Y EXTERNA", Arrays.asList(new Activity("Estado general de sellos"), new Activity("Aparicion de manchas de humedad de plafones"), new Activity("Daños o dobleces en ductos"), new Activity("Revision de estado de aislamiento de ductos"), new Activity("Revision de limpieza y fijacion de rejillas"))));
-      sections.add(new Section("varios", "VARIOS", Arrays.asList(new Activity("Revision de limpieza y estado de drenaje P.V.C. de condensados"), new Activity("Revision y colocacion de tornillera en todas las tapas"), new Activity("Revision de limpieza exterior del equipo (laminaciones)"))));
-      sections.add(new Section("evaporadores", "EVAPORADORES", Arrays.asList(new Activity("Revisar si tiene filtros, portafiltros y evaluacion del estado general"), new Activity("Revision de limpieza en serpentin"), new Activity("Revision de la charola de condensados del evaporador"), new Activity("Revision de motores, bandas y chumaceras"))));
-      sections.add(new Section("condensador", "CONDENSADOR", Arrays.asList(new Activity("Revision de limpieza en serpentin"), new Activity("Revision de laminillas del condensador"), new Activity("Revision de la vibracion en motores y compresores"), new Activity("Evaluacion del estado de conexiones electricas"), new Activity("Verificar carga adecuada de refrigerante"))));
-      sections.add(new Section("tablero", "TABLERO ELÉCTRICO", Arrays.asList(new Activity("Revision de conexiones electricas"), new Activity("Verificar platinos de contactores"))));
+      sections.add(new Section("ducteria", "DUCTERIA INTERNA Y EXTERNA",
+            Arrays.asList(new Activity("Estado general de sellos"),
+                  new Activity("Aparicion de manchas de humedad de plafones"),
+                  new Activity("Daños o dobleces en ductos"),
+                  new Activity("Revision de estado de aislamiento de ductos"),
+                  new Activity("Revision de limpieza y fijacion de rejillas"))));
+      sections.add(new Section("varios", "VARIOS",
+            Arrays.asList(new Activity("Revision de limpieza y estado de drenaje P.V.C. de condensados"),
+                  new Activity("Revision y colocacion de tornillera en todas las tapas"),
+                  new Activity("Revision de limpieza exterior del equipo (laminaciones)"))));
+      sections.add(new Section("evaporadores", "EVAPORADORES",
+            Arrays.asList(new Activity("Revisar si tiene filtros, portafiltros y evaluacion del estado general"),
+                  new Activity("Revision de limpieza en serpentin"),
+                  new Activity("Revision de la charola de condensados del evaporador"),
+                  new Activity("Revision de motores, bandas y chumaceras"))));
+      sections.add(new Section("condensador", "CONDENSADOR",
+            Arrays.asList(new Activity("Revision de limpieza en serpentin"),
+                  new Activity("Revision de laminillas del condensador"),
+                  new Activity("Revision de la vibracion en motores y compresores"),
+                  new Activity("Evaluacion del estado de conexiones electricas"),
+                  new Activity("Verificar carga adecuada de refrigerante"))));
+      sections.add(new Section("tablero", "TABLERO ELÉCTRICO",
+            Arrays.asList(new Activity("Revision de conexiones electricas"),
+                  new Activity("Verificar platinos de contactores"))));
       request.setAttribute("sections", sections);
+
+      String ordenServicio = request.getParameter("ordenServicio");
+      if (ordenServicio != null && !ordenServicio.isEmpty()) {
+         try (Connection conn = dataSource.getConnection();
+               PreparedStatement stmt = conn.prepareStatement(
+                     "SELECT data FROM airecondicionado_data WHERE orden_servicio = ?")) {
+            stmt.setString(1, ordenServicio);
+            try (ResultSet rs = stmt.executeQuery()) {
+               if (rs.next()) {
+                  JSONObject json = new JSONObject(rs.getString("data"));
+                  request.setAttribute("savedData", json.toMap());
+               }
+            }
+         } catch (SQLException e) {
+            throw new ServletException("Unable to load saved maintenance data", e);
+         }
+      }
+
       request.getRequestDispatcher("/MaintenanceForm.jsp").forward(request, response);
    }
 }


### PR DESCRIPTION
## Summary
- Fetch saved JSON for air conditioning forms and expose as `savedData` to JSPs
- Do the same for refrigeration checklist data
- Pre-fill checklist headers, service rows and reading blocks with stored values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a43925ab883329073c605a8da4de7