### PR TITLE
Replace fn:concat usage in checklist JSPs

### DIFF
--- a/jsp/checklist/aireCondicionado/ChecklistSection.jsp
+++ b/jsp/checklist/aireCondicionado/ChecklistSection.jsp
@@ -20,7 +20,7 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="inputName" value="${fn:replace(fn:concat(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), '-Bien'), ' ', '_')}" />
+            <c:set var="inputName" value="${fn:replace(fn:join(['status-', sectionTitle, '-', status.index, '-Bien'], ''), ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
@@ -58,13 +58,13 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="nameBase" value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
+            <c:set var="nameBase" value="${fn:replace(fn:join(['status-', sectionTitle, '-', status.index], ''), ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
               </td>
               <c:forEach var="zone" items="${['Juegos', 'Comedor', 'Cocina', 'Baos']}">
-                <c:set var="inputName" value="${fn:replace(fn:concat(nameBase, fn:concat('-', zone)), ' ', '_')}" />
+                <c:set var="inputName" value="${fn:replace(fn:join([nameBase, '-', zone], ''), ' ', '_')}" />
                 <td class="py-2 px-2 border-b border-r border-gray-300 text-center">
                   <div class="flex justify-center space-x-4">
                     <label class="inline-flex items-center">

--- a/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
@@ -14,25 +14,25 @@
       <tr>
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-<input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_voltage_AB')]}"/>
+<input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_voltage_AB'], '')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-<input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_voltage_BC')]}"/>
+<input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_voltage_BC'], '')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-<input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_voltage_CA')]}"/>
+<input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_voltage_CA'], '')]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-<input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_amp_A')]}"/>
+<input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_amp_A'], '')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-<input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_amp_B')]}"/>
+<input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_amp_B'], '')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-<input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_amp_C')]}"/>
+<input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_amp_C'], '')]}"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
@@ -15,7 +15,7 @@
           Medición de presión (colocar valor psi) ALTA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_presion_alta')]}"/>
+          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_presion_alta'], '')]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
@@ -23,7 +23,7 @@
           Medición de presión (colocar valor psi) BAJA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_presion_baja')]}"/>
+          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_presion_baja'], '')]}"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/refrigeracion/ChecklistSection.jsp
+++ b/jsp/checklist/refrigeracion/ChecklistSection.jsp
@@ -19,9 +19,9 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="baseName" value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
-            <c:set var="nameBien" value="${fn:concat(baseName,'-Bien')}" />
-            <c:set var="nameMal" value="${fn:concat(baseName,'-Mal')}" />
+            <c:set var="baseName" value="${fn:replace(fn:join(['status-', sectionTitle, '-', status.index], ''), ' ', '_')}" />
+            <c:set var="nameBien" value="${baseName}-Bien" />
+            <c:set var="nameMal" value="${baseName}-Mal" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
@@ -57,13 +57,13 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="nameBase" value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
+            <c:set var="nameBase" value="${fn:replace(fn:join(['status-', sectionTitle, '-', status.index], ''), ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
               </td>
               <c:forEach var="zone" items="${['Conservacion','Freezer']}">
-                <c:set var="inputName" value="${fn:replace(fn:concat(nameBase, fn:concat('-', zone)), ' ', '_')}" />
+                <c:set var="inputName" value="${fn:replace(fn:join([nameBase, '-', zone], ''), ' ', '_')}" />
                 <td class="py-2 px-2 border-b border-r border-gray-300 text-center">
                   <div class="flex justify-center space-x-4">
                     <label class="inline-flex items-center">

--- a/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
@@ -14,25 +14,25 @@
       <tr>
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_voltage_AB')]}"/>
+          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_voltage_AB'], '')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_voltage_BC')]}"/>
+          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_voltage_BC'], '')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_voltage_CA')]}"/>
+          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_voltage_CA'], '')]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_amp_A')]}"/>
+          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_amp_A'], '')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_amp_B')]}"/>
+          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_amp_B'], '')]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_amp_C')]}"/>
+          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_amp_C'], '')]}"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
@@ -15,7 +15,7 @@
           Medición de presión (colocar valor psi) ALTA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_presion_alta')]}"/>
+          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_presion_alta'], '')]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
@@ -23,7 +23,7 @@
           Medición de presión (colocar valor psi) BAJA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:concat(base,'_presion_baja')]}"/>
+          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_presion_baja'], '')]}"/>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Summary
- eliminate JSTL fn:concat calls in checklist views using EL or fn:join
- adjust operation and pressure partials to build map keys with fn:join

## Testing
- `java org.apache.jasper.JspC -help` *(fails: Could not find or load main class org.apache.jasper.JspC)*
- `apt-get update` *(fails: repositories not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a781d72248332bbb099d5b8b58d5c