### PR TITLE
refactor: replace fn join with concat in AC checklist

### DIFF
--- a/jsp/checklist/aireCondicionado/ChecklistSection.jsp
+++ b/jsp/checklist/aireCondicionado/ChecklistSection.jsp
@@ -20,7 +20,8 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="inputName" value="${fn:replace(fn:join(['status-', sectionTitle, '-', status.index, '-Bien'], ''), ' ', '_')}" />
+            <c:set var="inputName"
+              value="${fn:replace(fn:concat(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), '-Bien'), ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
@@ -58,13 +59,15 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="nameBase" value="${fn:replace(fn:join(['status-', sectionTitle, '-', status.index], ''), ' ', '_')}" />
+            <c:set var="nameBase"
+              value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
               </td>
               <c:forEach var="zone" items="${['Juegos', 'Comedor', 'Cocina', 'Baos']}">
-                <c:set var="inputName" value="${fn:replace(fn:join([nameBase, '-', zone], ''), ' ', '_')}" />
+                <c:set var="inputName"
+                  value="${fn:replace(fn:concat(nameBase, fn:concat('-', zone)), ' ', '_')}" />
                 <td class="py-2 px-2 border-b border-r border-gray-300 text-center">
                   <div class="flex justify-center space-x-4">
                     <label class="inline-flex items-center">


### PR DESCRIPTION
## Summary
- replace fn:join with nested fn:concat calls when building input names in AC checklist JSP

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7bcc74808332a4e6797319fbea44