### PR TITLE
Fix JSTL concat error in checklist JSP

### DIFF
--- a/jsp/checklist/aireCondicionado/ChecklistSection.jsp
+++ b/jsp/checklist/aireCondicionado/ChecklistSection.jsp
@@ -20,8 +20,8 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="inputName"
-              value="${fn:replace(fn:concat(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), '-Bien'), ' ', '_')}" />
+            <c:set var="inputNameRaw">status-${sectionTitle}-${status.index}-Bien</c:set>
+            <c:set var="inputName" value="${fn:replace(inputNameRaw, ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
@@ -59,15 +59,15 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="nameBase"
-              value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
+            <c:set var="nameBaseRaw">status-${sectionTitle}-${status.index}</c:set>
+            <c:set var="nameBase" value="${fn:replace(nameBaseRaw, ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
               </td>
               <c:forEach var="zone" items="${['Juegos', 'Comedor', 'Cocina', 'Baos']}">
-                <c:set var="inputName"
-                  value="${fn:replace(fn:concat(nameBase, fn:concat('-', zone)), ' ', '_')}" />
+                <c:set var="inputNameRaw">${nameBase}-${zone}</c:set>
+                <c:set var="inputName" value="${fn:replace(inputNameRaw, ' ', '_')}" />
                 <td class="py-2 px-2 border-b border-r border-gray-300 text-center">
                   <div class="flex justify-center space-x-4">
                     <label class="inline-flex items-center">


### PR DESCRIPTION
## Summary
- Build checklist input names without using `fn:concat` to avoid missing function errors

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a8b6de1488332b9605504db6fc6ed