### PR TITLE
Fix saved data conversion without JSONObject.toMap

### DIFF
--- a/jsp/checklist/aireCondicionado/loadData.jspf
+++ b/jsp/checklist/aireCondicionado/loadData.jspf
@@ -1,4 +1,4 @@
-<%@ page import="java.util.Map, javax.naming.InitialContext, javax.sql.DataSource, java.sql.*, org.json.JSONObject" %>
+<%@ page import="java.util.Map, javax.naming.InitialContext, javax.sql.DataSource, java.sql.*, com.google.gson.Gson" %>
 <%
 Map<String, Object> savedData = (Map<String, Object>) request.getAttribute("savedData");
 if (savedData == null) {
@@ -13,8 +13,8 @@ if (savedData == null) {
                 stmt.setString(1, ordenServicio);
                 try (ResultSet rs = stmt.executeQuery()) {
                     if (rs.next()) {
-                        JSONObject json = new JSONObject(rs.getString("data"));
-                        savedData = json.toMap();
+                        Gson gson = new Gson();
+                        savedData = gson.fromJson(rs.getString("data"), Map.class);
                         request.setAttribute("savedData", savedData);
                     }
                 }

--- a/jsp/checklist/refrigeracion/loadData.jspf
+++ b/jsp/checklist/refrigeracion/loadData.jspf
@@ -1,4 +1,4 @@
-<%@ page import="java.util.Map, javax.naming.InitialContext, javax.sql.DataSource, java.sql.*, org.json.JSONObject" %>
+<%@ page import="java.util.Map, javax.naming.InitialContext, javax.sql.DataSource, java.sql.*, com.google.gson.Gson" %>
 <%
 Map<String, Object> savedData = (Map<String, Object>) request.getAttribute("savedData");
 if (savedData == null) {
@@ -13,8 +13,8 @@ if (savedData == null) {
                 stmt.setString(1, ordenServicio);
                 try (ResultSet rs = stmt.executeQuery()) {
                     if (rs.next()) {
-                        JSONObject json = new JSONObject(rs.getString("data"));
-                        savedData = json.toMap();
+                        Gson gson = new Gson();
+                        savedData = gson.fromJson(rs.getString("data"), Map.class);
                         request.setAttribute("savedData", savedData);
                     }
                 }

--- a/src/servlet/MaintenanceFormServlet.java
+++ b/src/servlet/MaintenanceFormServlet.java
@@ -16,7 +16,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 
-import org.json.JSONObject;
+import com.google.gson.Gson;
+import java.util.Map;
 
 import clases.Activity;
 import clases.Section;
@@ -66,8 +67,9 @@ public class MaintenanceFormServlet extends HttpServlet {
             stmt.setString(1, ordenServicio);
             try (ResultSet rs = stmt.executeQuery()) {
                if (rs.next()) {
-                  JSONObject json = new JSONObject(rs.getString("data"));
-                  request.setAttribute("savedData", json.toMap());
+                  Gson gson = new Gson();
+                  Map<String, Object> savedData = gson.fromJson(rs.getString("data"), Map.class);
+                  request.setAttribute("savedData", savedData);
                }
             }
          } catch (SQLException e) {

--- a/src/servlet/RefrigeracionFormServlet.java
+++ b/src/servlet/RefrigeracionFormServlet.java
@@ -17,7 +17,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 
-import org.json.JSONObject;
+import com.google.gson.Gson;
+import java.util.Map;
 
 import clases.Activity;
 import clases.Section;
@@ -89,8 +90,9 @@ public class RefrigeracionFormServlet extends HttpServlet {
             stmt.setString(1, ordenServicio);
             try (ResultSet rs = stmt.executeQuery()) {
                if (rs.next()) {
-                  JSONObject json = new JSONObject(rs.getString("data"));
-                  request.setAttribute("savedData", json.toMap());
+                  Gson gson = new Gson();
+                  Map<String, Object> savedData = gson.fromJson(rs.getString("data"), Map.class);
+                  request.setAttribute("savedData", savedData);
                }
             }
          } catch (SQLException e) {


### PR DESCRIPTION
## Summary
- Replace unavailable `JSONObject.toMap()` usage with Gson-based Map conversion in maintenance and refrigeration servlets and JSP helpers
- Import Gson and Map where needed to handle JSON persistence correctly

## Testing
- `mvn -q test` *(fails: MissingProjectException)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a914dd9d08332aa5cd09901522ded