### PR TITLE
Fix maintenance form JSP paths

### DIFF
--- a/src/servlet/MaintenanceFormServlet.java
+++ b/src/servlet/MaintenanceFormServlet.java
@@ -77,6 +77,6 @@ public class MaintenanceFormServlet extends HttpServlet {
          }
       }
 
-      request.getRequestDispatcher("/MaintenanceForm.jsp").forward(request, response);
+      request.getRequestDispatcher("/jsp/MaintenanceForm.jsp").forward(request, response);
    }
 }

--- a/src/servlet/RefrigeracionFormServlet.java
+++ b/src/servlet/RefrigeracionFormServlet.java
@@ -100,6 +100,6 @@ public class RefrigeracionFormServlet extends HttpServlet {
          }
       }
 
-      request.getRequestDispatcher("/MaintenanceFormRefrigeracion.jsp").forward(request, response);
+      request.getRequestDispatcher("/jsp/MaintenanceFormRefrigeracion.jsp").forward(request, response);
    }
 }


### PR DESCRIPTION
## Summary
- Correct dispatcher targets for maintenance form JSPs

## Testing
- `javac src/servlet/MaintenanceFormServlet.java src/servlet/RefrigeracionFormServlet.java src/clases/Activity.java src/clases/Section.java` *(fails: package javax.annotation does not exist)*
- `apt-get install -y libservlet-api-java libgoogle-gson-java` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689a96fb12bc8332abdb1c9896403845