### PR TITLE
Replace fn:join with fn:concat in checklist JSP

### DIFF
--- a/jsp/checklist/refrigeracion/ChecklistSection.jsp
+++ b/jsp/checklist/refrigeracion/ChecklistSection.jsp
@@ -20,7 +20,7 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="baseName" value="${fn:replace(fn:join(['status-', sectionTitle, '-', status.index], ''), ' ', '_')}" />
+            <c:set var="baseName" value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
             <c:set var="nameBien" value="${baseName}-Bien" />
             <c:set var="nameMal" value="${baseName}-Mal" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
@@ -58,13 +58,13 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="nameBase" value="${fn:replace(fn:join(['status-', sectionTitle, '-', status.index], ''), ' ', '_')}" />
+            <c:set var="nameBase" value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
               </td>
               <c:forEach var="zone" items="${['Conservacion','Freezer']}">
-                <c:set var="inputName" value="${fn:replace(fn:join([nameBase, '-', zone], ''), ' ', '_')}" />
+                <c:set var="inputName" value="${fn:replace(fn:concat(nameBase, fn:concat('-', zone)), ' ', '_')}" />
                 <td class="py-2 px-2 border-b border-r border-gray-300 text-center">
                   <div class="flex justify-center space-x-4">
                     <label class="inline-flex items-center">


### PR DESCRIPTION
## Summary
- Build checklist input names using `fn:concat` instead of `fn:join` to avoid ArrayList conversion errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a98aac3e883328dc36c1801e58788