### PR TITLE
Fix JSTL concat errors in checklist section

### DIFF
--- a/jsp/checklist/refrigeracion/ChecklistSection.jsp
+++ b/jsp/checklist/refrigeracion/ChecklistSection.jsp
@@ -20,7 +20,7 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="baseName" value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
+            <c:set var="baseName" value="${fn:replace('status-' + sectionTitle + '-' + status.index, ' ', '_')}" />
             <c:set var="nameBien" value="${baseName}-Bien" />
             <c:set var="nameMal" value="${baseName}-Mal" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
@@ -58,13 +58,13 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="nameBase" value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
+            <c:set var="nameBase" value="${fn:replace('status-' + sectionTitle + '-' + status.index, ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
               </td>
               <c:forEach var="zone" items="${['Conservacion','Freezer']}">
-                <c:set var="inputName" value="${fn:replace(fn:concat(nameBase, fn:concat('-', zone)), ' ', '_')}" />
+                <c:set var="inputName" value="${fn:replace(nameBase + '-' + zone, ' ', '_')}" />
                 <td class="py-2 px-2 border-b border-r border-gray-300 text-center">
                   <div class="flex justify-center space-x-4">
                     <label class="inline-flex items-center">


### PR DESCRIPTION
## Summary
- Replace invalid `fn:concat` JSTL calls with EL string concatenation in refrigeración checklist

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a9a19434083328e66913aaff2245b