### PR TITLE
Load saved checklist data in maintenance and refrigeration forms

### DIFF
--- a/jsp/MaintenanceForm.jsp
+++ b/jsp/MaintenanceForm.jsp
@@ -2,6 +2,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ page import="clases.Activity"%>
 <%@ page import="clases.Section"%>
+<%@ include file="checklist/aireCondicionado/loadData.jspf" %>
 
 <html>
 <head>

--- a/jsp/MaintenanceFormRefrigeracion.jsp
+++ b/jsp/MaintenanceFormRefrigeracion.jsp
@@ -2,6 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ page import="clases.Activity"%>
 <%@ page import="clases.Section"%>
+<%@ include file="checklist/refrigeracion/loadData.jspf" %>
 
 <html>
 <head>

--- a/jsp/checklist/aireCondicionado/loadData.jspf
+++ b/jsp/checklist/aireCondicionado/loadData.jspf
@@ -3,6 +3,9 @@
 Map<String, Object> savedData = (Map<String, Object>) request.getAttribute("savedData");
 if (savedData == null) {
     String ordenServicio = request.getParameter("ordenServicio");
+    if (ordenServicio == null || ordenServicio.isEmpty()) {
+        ordenServicio = request.getParameter("orden");
+    }
     if (ordenServicio != null && !ordenServicio.isEmpty()) {
         try {
             InitialContext ctx = new InitialContext();

--- a/jsp/checklist/refrigeracion/loadData.jspf
+++ b/jsp/checklist/refrigeracion/loadData.jspf
@@ -3,6 +3,9 @@
 Map<String, Object> savedData = (Map<String, Object>) request.getAttribute("savedData");
 if (savedData == null) {
     String ordenServicio = request.getParameter("ordenServicio");
+    if (ordenServicio == null || ordenServicio.isEmpty()) {
+        ordenServicio = request.getParameter("orden");
+    }
     if (ordenServicio != null && !ordenServicio.isEmpty()) {
         try {
             InitialContext ctx = new InitialContext();

--- a/src/servlet/MaintenanceDataServlet.java
+++ b/src/servlet/MaintenanceDataServlet.java
@@ -46,6 +46,9 @@ public class MaintenanceDataServlet extends HttpServlet {
             }
             json = new JSONObject(body.toString());
             ordenServicio = json.optString("ordenServicio", null);
+            if (ordenServicio == null || ordenServicio.isEmpty()) {
+                ordenServicio = json.optString("orden", null);
+            }
         } else {
             Map<String, String[]> params = request.getParameterMap();
             for (Map.Entry<String, String[]> entry : params.entrySet()) {
@@ -59,6 +62,9 @@ public class MaintenanceDataServlet extends HttpServlet {
                 }
             }
             ordenServicio = request.getParameter("ordenServicio");
+            if (ordenServicio == null || ordenServicio.isEmpty()) {
+                ordenServicio = request.getParameter("orden");
+            }
         }
 
         if (ordenServicio == null || ordenServicio.isEmpty()) {
@@ -108,6 +114,9 @@ public class MaintenanceDataServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         String ordenServicio = request.getParameter("ordenServicio");
+        if (ordenServicio == null || ordenServicio.isEmpty()) {
+            ordenServicio = request.getParameter("orden");
+        }
         if (ordenServicio == null || ordenServicio.isEmpty()) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing ordenServicio");
             return;

--- a/src/servlet/MaintenanceFormServlet.java
+++ b/src/servlet/MaintenanceFormServlet.java
@@ -60,6 +60,9 @@ public class MaintenanceFormServlet extends HttpServlet {
       request.setAttribute("sections", sections);
 
       String ordenServicio = request.getParameter("ordenServicio");
+      if (ordenServicio == null || ordenServicio.isEmpty()) {
+         ordenServicio = request.getParameter("orden");
+      }
       if (ordenServicio != null && !ordenServicio.isEmpty()) {
          try (Connection conn = dataSource.getConnection();
                PreparedStatement stmt = conn.prepareStatement(

--- a/src/servlet/RefrigeracionDataServlet.java
+++ b/src/servlet/RefrigeracionDataServlet.java
@@ -46,6 +46,9 @@ public class RefrigeracionDataServlet extends HttpServlet {
             }
             json = new JSONObject(body.toString());
             ordenServicio = json.optString("ordenServicio", null);
+            if (ordenServicio == null || ordenServicio.isEmpty()) {
+                ordenServicio = json.optString("orden", null);
+            }
         } else {
             Map<String, String[]> params = request.getParameterMap();
             for (Map.Entry<String, String[]> entry : params.entrySet()) {
@@ -59,6 +62,9 @@ public class RefrigeracionDataServlet extends HttpServlet {
                 }
             }
             ordenServicio = request.getParameter("ordenServicio");
+            if (ordenServicio == null || ordenServicio.isEmpty()) {
+                ordenServicio = request.getParameter("orden");
+            }
         }
 
         if (ordenServicio == null || ordenServicio.isEmpty()) {
@@ -108,6 +114,9 @@ public class RefrigeracionDataServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         String ordenServicio = request.getParameter("ordenServicio");
+        if (ordenServicio == null || ordenServicio.isEmpty()) {
+            ordenServicio = request.getParameter("orden");
+        }
         if (ordenServicio == null || ordenServicio.isEmpty()) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing ordenServicio");
             return;

--- a/src/servlet/RefrigeracionFormServlet.java
+++ b/src/servlet/RefrigeracionFormServlet.java
@@ -83,6 +83,9 @@ public class RefrigeracionFormServlet extends HttpServlet {
       request.setAttribute("sections", sections);
 
       String ordenServicio = request.getParameter("ordenServicio");
+      if (ordenServicio == null || ordenServicio.isEmpty()) {
+         ordenServicio = request.getParameter("orden");
+      }
       if (ordenServicio != null && !ordenServicio.isEmpty()) {
          try (Connection conn = dataSource.getConnection();
                PreparedStatement stmt = conn.prepareStatement(


### PR DESCRIPTION
## Summary
- Load saved checklist data when `orden` or `ordenServicio` is supplied for both maintenance and refrigeration forms.
- Include loadData fragments on top-level JSPs so every section can access previously saved fields.

## Testing
- `javac -cp WEB-INF/lib/*:src src/servlet/MaintenanceFormServlet.java src/servlet/RefrigeracionFormServlet.java src/servlet/MaintenanceDataServlet.java src/servlet/RefrigeracionDataServlet.java` *(fails: package javax.annotation does not exist)*
- `node test/tests.js` *(fails: ReferenceError: $ is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689abbd775e08332b47ca60c4dd00f90