### PR TITLE
Load saved checklist data in maintenance and refrigeration forms

### DIFF
--- a/jsp/MaintenanceForm.jsp
+++ b/jsp/MaintenanceForm.jsp
@@ -2,6 +2,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ page import="clases.Activity"%>
 <%@ page import="clases.Section"%>
+<%@ include file="checklist/aireCondicionado/loadData.jspf" %>
 
 <html>
 <head>

--- a/jsp/MaintenanceFormRefrigeracion.jsp
+++ b/jsp/MaintenanceFormRefrigeracion.jsp
@@ -2,6 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ page import="clases.Activity"%>
 <%@ page import="clases.Section"%>
+<%@ include file="checklist/refrigeracion/loadData.jspf" %>
 
 <html>
 <head>

--- a/jsp/checklist/aireCondicionado/loadData.jspf
+++ b/jsp/checklist/aireCondicionado/loadData.jspf
@@ -3,6 +3,9 @@
 Map<String, Object> savedData = (Map<String, Object>) request.getAttribute("savedData");
 if (savedData == null) {
     String ordenServicio = request.getParameter("ordenServicio");
+    if (ordenServicio == null || ordenServicio.isEmpty()) {
+        ordenServicio = request.getParameter("orden");
+    }
     if (ordenServicio != null && !ordenServicio.isEmpty()) {
         try {
             InitialContext ctx = new InitialContext();

--- a/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
@@ -15,25 +15,31 @@
       <tr>
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-<input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_voltage_AB'], '')]}"/>
+          <c:set var="voltageABKey">${base}_voltage_AB</c:set>
+          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[voltageABKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-<input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_voltage_BC'], '')]}"/>
+          <c:set var="voltageBCKey">${base}_voltage_BC</c:set>
+          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[voltageBCKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-<input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_voltage_CA'], '')]}"/>
+          <c:set var="voltageCAKey">${base}_voltage_CA</c:set>
+          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[voltageCAKey]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-<input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_amp_A'], '')]}"/>
+          <c:set var="ampAKey">${base}_amp_A</c:set>
+          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[ampAKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-<input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_amp_B'], '')]}"/>
+          <c:set var="ampBKey">${base}_amp_B</c:set>
+          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[ampBKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-<input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_amp_C'], '')]}"/>
+          <c:set var="ampCKey">${base}_amp_C</c:set>
+          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[ampCKey]}"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
@@ -16,7 +16,8 @@
           Medición de presión (colocar valor psi) ALTA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_presion_alta'], '')]}"/>
+          <c:set var="presionAltaKey">${base}_presion_alta</c:set>
+          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[presionAltaKey]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
@@ -24,7 +25,8 @@
           Medición de presión (colocar valor psi) BAJA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_presion_baja'], '')]}"/>
+          <c:set var="presionBajaKey">${base}_presion_baja</c:set>
+          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[presionBajaKey]}"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/refrigeracion/ChecklistSection.jsp
+++ b/jsp/checklist/refrigeracion/ChecklistSection.jsp
@@ -20,9 +20,8 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="baseName" value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
-            <c:set var="nameBien" value="${fn:concat(baseName, '-Bien')}" />
-            <c:set var="nameMal" value="${fn:concat(baseName, '-Mal')}" />
+            <c:set var="inputNameRaw">status-${sectionTitle}-${status.index}-Bien</c:set>
+            <c:set var="nameBien" value="${fn:replace(inputNameRaw, ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
@@ -58,13 +57,15 @@
         </thead>
         <tbody>
           <c:forEach var="activity" items="${activities}" varStatus="status">
-            <c:set var="nameBase" value="${fn:replace(fn:concat(fn:concat('status-', sectionTitle), fn:concat('-', status.index)), ' ', '_')}" />
+            <c:set var="nameBaseRaw">status-${sectionTitle}-${status.index}</c:set>
+            <c:set var="nameBase" value="${fn:replace(nameBaseRaw, ' ', '_')}" />
             <tr class="${status.index % 2 == 0 ? 'bg-white' : 'bg-gray-50'}">
               <td class="py-2 px-4 border-b border-r border-gray-300 text-sm text-gray-800">
                 ${activity.name}
               </td>
               <c:forEach var="zone" items="${['Conservacion','Freezer']}">
-                <c:set var="inputName" value="${fn:replace(fn:concat(fn:concat(nameBase, '-'), zone), ' ', '_')}" />
+                <c:set var="inputNameRaw">${nameBase}-${zone}</c:set>
+                <c:set var="inputName" value="${fn:replace(inputNameRaw, ' ', '_')}" />
                 <td class="py-2 px-2 border-b border-r border-gray-300 text-center">
                   <div class="flex justify-center space-x-4">
                     <label class="inline-flex items-center">

--- a/jsp/checklist/refrigeracion/loadData.jspf
+++ b/jsp/checklist/refrigeracion/loadData.jspf
@@ -3,6 +3,9 @@
 Map<String, Object> savedData = (Map<String, Object>) request.getAttribute("savedData");
 if (savedData == null) {
     String ordenServicio = request.getParameter("ordenServicio");
+    if (ordenServicio == null || ordenServicio.isEmpty()) {
+        ordenServicio = request.getParameter("orden");
+    }
     if (ordenServicio != null && !ordenServicio.isEmpty()) {
         try {
             InitialContext ctx = new InitialContext();

--- a/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
@@ -15,25 +15,31 @@
       <tr>
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_voltage_AB'], '')]}"/>
+          <c:set var="voltageABKey">${base}_voltage_AB</c:set>
+          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[voltageABKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_voltage_BC'], '')]}"/>
+          <c:set var="voltageBCKey">${base}_voltage_BC</c:set>
+          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[voltageBCKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_voltage_CA'], '')]}"/>
+          <c:set var="voltageCAKey">${base}_voltage_CA</c:set>
+          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[voltageCAKey]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_amp_A'], '')]}"/>
+          <c:set var="ampAKey">${base}_amp_A</c:set>
+          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[ampAKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
-          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_amp_B'], '')]}"/>
+          <c:set var="ampBKey">${base}_amp_B</c:set>
+          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[ampBKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_amp_C'], '')]}"/>
+          <c:set var="ampCKey">${base}_amp_C</c:set>
+          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[ampCKey]}"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
@@ -16,7 +16,8 @@
           Medición de presión (colocar valor psi) ALTA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_presion_alta'], '')]}"/>
+          <c:set var="presionAltaKey">${base}_presion_alta</c:set>
+          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[presionAltaKey]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
@@ -24,7 +25,8 @@
           Medición de presión (colocar valor psi) BAJA
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
-          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[fn:join([base, '_presion_baja'], '')]}"/>
+          <c:set var="presionBajaKey">${base}_presion_baja</c:set>
+          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[presionBajaKey]}"/>
         </td>
       </tr>
     </tbody>

--- a/src/servlet/MaintenanceDataServlet.java
+++ b/src/servlet/MaintenanceDataServlet.java
@@ -46,6 +46,9 @@ public class MaintenanceDataServlet extends HttpServlet {
             }
             json = new JSONObject(body.toString());
             ordenServicio = json.optString("ordenServicio", null);
+            if (ordenServicio == null || ordenServicio.isEmpty()) {
+                ordenServicio = json.optString("orden", null);
+            }
         } else {
             Map<String, String[]> params = request.getParameterMap();
             for (Map.Entry<String, String[]> entry : params.entrySet()) {
@@ -59,6 +62,9 @@ public class MaintenanceDataServlet extends HttpServlet {
                 }
             }
             ordenServicio = request.getParameter("ordenServicio");
+            if (ordenServicio == null || ordenServicio.isEmpty()) {
+                ordenServicio = request.getParameter("orden");
+            }
         }
 
         if (ordenServicio == null || ordenServicio.isEmpty()) {
@@ -108,6 +114,9 @@ public class MaintenanceDataServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         String ordenServicio = request.getParameter("ordenServicio");
+        if (ordenServicio == null || ordenServicio.isEmpty()) {
+            ordenServicio = request.getParameter("orden");
+        }
         if (ordenServicio == null || ordenServicio.isEmpty()) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing ordenServicio");
             return;

--- a/src/servlet/MaintenanceFormServlet.java
+++ b/src/servlet/MaintenanceFormServlet.java
@@ -60,6 +60,9 @@ public class MaintenanceFormServlet extends HttpServlet {
       request.setAttribute("sections", sections);
 
       String ordenServicio = request.getParameter("ordenServicio");
+      if (ordenServicio == null || ordenServicio.isEmpty()) {
+         ordenServicio = request.getParameter("orden");
+      }
       if (ordenServicio != null && !ordenServicio.isEmpty()) {
          try (Connection conn = dataSource.getConnection();
                PreparedStatement stmt = conn.prepareStatement(

--- a/src/servlet/RefrigeracionDataServlet.java
+++ b/src/servlet/RefrigeracionDataServlet.java
@@ -46,6 +46,9 @@ public class RefrigeracionDataServlet extends HttpServlet {
             }
             json = new JSONObject(body.toString());
             ordenServicio = json.optString("ordenServicio", null);
+            if (ordenServicio == null || ordenServicio.isEmpty()) {
+                ordenServicio = json.optString("orden", null);
+            }
         } else {
             Map<String, String[]> params = request.getParameterMap();
             for (Map.Entry<String, String[]> entry : params.entrySet()) {
@@ -59,6 +62,9 @@ public class RefrigeracionDataServlet extends HttpServlet {
                 }
             }
             ordenServicio = request.getParameter("ordenServicio");
+            if (ordenServicio == null || ordenServicio.isEmpty()) {
+                ordenServicio = request.getParameter("orden");
+            }
         }
 
         if (ordenServicio == null || ordenServicio.isEmpty()) {
@@ -108,6 +114,9 @@ public class RefrigeracionDataServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         String ordenServicio = request.getParameter("ordenServicio");
+        if (ordenServicio == null || ordenServicio.isEmpty()) {
+            ordenServicio = request.getParameter("orden");
+        }
         if (ordenServicio == null || ordenServicio.isEmpty()) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing ordenServicio");
             return;

--- a/src/servlet/RefrigeracionFormServlet.java
+++ b/src/servlet/RefrigeracionFormServlet.java
@@ -83,6 +83,9 @@ public class RefrigeracionFormServlet extends HttpServlet {
       request.setAttribute("sections", sections);
 
       String ordenServicio = request.getParameter("ordenServicio");
+      if (ordenServicio == null || ordenServicio.isEmpty()) {
+         ordenServicio = request.getParameter("orden");
+      }
       if (ordenServicio != null && !ordenServicio.isEmpty()) {
          try (Connection conn = dataSource.getConnection();
                PreparedStatement stmt = conn.prepareStatement(


### PR DESCRIPTION
## Summary
- Build saved-data field keys with `c:set` in operation and pressure blocks so checklist inputs pre-fill without using concat
- Generate refrigeration checklist section input names via `c:set` instead of concat for consistent saved-data lookups

## Testing
- `javac -cp WEB-INF/lib/*:src src/servlet/MaintenanceFormServlet.java src/servlet/RefrigeracionFormServlet.java src/servlet/MaintenanceDataServlet.java src/servlet/RefrigeracionDataServlet.java` *(fails: package javax.annotation does not exist)*
- `node test/tests.js` *(fails: ReferenceError: $ is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689abbd775e08332b47ca60c4dd00f90