### PR TITLE
Fix data loading in checklist operation and pressure blocks

### DIFF
--- a/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
@@ -16,30 +16,30 @@
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
           <c:set var="voltageABKey">${base}_voltage_AB</c:set>
-          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[voltageABKey]}"/>
+          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[voltageABKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
           <c:set var="voltageBCKey">${base}_voltage_BC</c:set>
-          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[voltageBCKey]}"/>
+          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[voltageBCKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
           <c:set var="voltageCAKey">${base}_voltage_CA</c:set>
-          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[voltageCAKey]}"/>
+          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[voltageCAKey]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
           <c:set var="ampAKey">${base}_amp_A</c:set>
-          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[ampAKey]}"/>
+          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[ampAKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
           <c:set var="ampBKey">${base}_amp_B</c:set>
-          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[ampBKey]}"/>
+          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[ampBKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
           <c:set var="ampCKey">${base}_amp_C</c:set>
-          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[ampCKey]}"/>
+          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[ampCKey]}"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
@@ -17,7 +17,7 @@
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
           <c:set var="presionAltaKey">${base}_presion_alta</c:set>
-          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[presionAltaKey]}"/>
+          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[presionAltaKey]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
@@ -26,7 +26,7 @@
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
           <c:set var="presionBajaKey">${base}_presion_baja</c:set>
-          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[presionBajaKey]}"/>
+          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[presionBajaKey]}"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
@@ -16,30 +16,30 @@
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
           <c:set var="voltageABKey">${base}_voltage_AB</c:set>
-          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[voltageABKey]}"/>
+          <input type="number" name="${base}_voltage_AB" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[voltageABKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
           <c:set var="voltageBCKey">${base}_voltage_BC</c:set>
-          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[voltageBCKey]}"/>
+          <input type="number" name="${base}_voltage_BC" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[voltageBCKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
           <c:set var="voltageCAKey">${base}_voltage_CA</c:set>
-          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[voltageCAKey]}"/>
+          <input type="number" name="${base}_voltage_CA" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[voltageCAKey]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
         <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
           <c:set var="ampAKey">${base}_amp_A</c:set>
-          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[ampAKey]}"/>
+          <input type="number" name="${base}_amp_A" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[ampAKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-r border-gray-300">
           <c:set var="ampBKey">${base}_amp_B</c:set>
-          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[ampBKey]}"/>
+          <input type="number" name="${base}_amp_B" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[ampBKey]}"/>
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
           <c:set var="ampCKey">${base}_amp_C</c:set>
-          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[ampCKey]}"/>
+          <input type="number" name="${base}_amp_C" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[ampCKey]}"/>
         </td>
       </tr>
     </tbody>

--- a/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
@@ -17,7 +17,7 @@
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
           <c:set var="presionAltaKey">${base}_presion_alta</c:set>
-          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[presionAltaKey]}"/>
+          <input type="number" name="${base}_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[presionAltaKey]}"/>
         </td>
       </tr>
       <tr class="bg-gray-50">
@@ -26,7 +26,7 @@
         </td>
         <td class="py-2 px-2 border-b border-gray-300">
           <c:set var="presionBajaKey">${base}_presion_baja</c:set>
-          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData[presionBajaKey]}"/>
+          <input type="number" name="${base}_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${requestScope.savedData[presionBajaKey]}"/>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Summary
- Use `requestScope.savedData` to populate input values in OperationBlock and PressureBlock JSP partials so saved data loads properly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689acd9480dc8332bcfdb010854a5be4