### PR TITLE
Fix data loading in checklist operation and pressure blocks

### DIFF
--- a/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ include file="../loadData.jspf" %>
+<c:set var="savedData" value="${requestScope.savedData}" />
 <c:set var="base" value="${fn:replace(param.title,' ','_')}" />
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 

--- a/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
@@ -2,6 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ include file="../loadData.jspf" %>
+<c:set var="savedData" value="${requestScope.savedData}" />
 <c:set var="base" value="${fn:replace(param.title,' ','_')}" />
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 

--- a/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ include file="../loadData.jspf" %>
+<c:set var="savedData" value="${requestScope.savedData}" />
 <c:set var="base" value="${fn:replace(param.title,' ','_')}" />
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 

--- a/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
@@ -2,6 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ include file="../loadData.jspf" %>
+<c:set var="savedData" value="${requestScope.savedData}" />
 <c:set var="base" value="${fn:replace(param.title,' ','_')}" />
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 


### PR DESCRIPTION
## Summary
- Mirror `savedData` request attribute into a JSP variable and use it to populate voltage and amperage fields in air-conditioning operation blocks
- Apply the same `savedData` lookup for air-conditioning pressure block inputs
- Use the `savedData` variable for refrigeration operation and pressure blocks so saved readings appear in the form

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689acd9480dc8332bcfdb010854a5be4