### PR TITLE
Fix data loading in checklist operation and pressure blocks

### DIFF
--- a/jsp/checklist/aireCondicionado/OperationReadings.jsp
+++ b/jsp/checklist/aireCondicionado/OperationReadings.jsp
@@ -8,41 +8,49 @@
     <%-- Operation: Juegos --%>
     <jsp:include page="partials/OperationBlock.jsp">
       <jsp:param name="title" value="Verificar condiciones de operación eléctrica de juegos"/>
+      <jsp:param name="base" value="juegos"/>
     </jsp:include>
 
     <%-- Operation: Cocina --%>
     <jsp:include page="partials/OperationBlock.jsp">
       <jsp:param name="title" value="Verificar condiciones de operación de cocina"/>
+      <jsp:param name="base" value="cocina"/>
     </jsp:include>
 
     <%-- Pressure: Juegos --%>
     <jsp:include page="partials/PressureBlock.jsp">
       <jsp:param name="title" value="Lecturas de presiones de operación de juegos"/>
+      <jsp:param name="base" value="juegos"/>
     </jsp:include>
 
     <%-- Pressure: Cocina --%>
     <jsp:include page="partials/PressureBlock.jsp">
       <jsp:param name="title" value="Lecturas de presiones de operación de cocina"/>
+      <jsp:param name="base" value="cocina"/>
     </jsp:include>
 
     <%-- Operation: Comedor --%>
     <jsp:include page="partials/OperationBlock.jsp">
       <jsp:param name="title" value="Verificar condiciones de operación eléctrica de comedor"/>
+      <jsp:param name="base" value="comedor"/>
     </jsp:include>
 
     <%-- Operation: Baños --%>
     <jsp:include page="partials/OperationBlock.jsp">
       <jsp:param name="title" value="Verificar condiciones de operación eléctrica de baños"/>
+      <jsp:param name="base" value="banos"/>
     </jsp:include>
 
     <%-- Pressure: Comedor --%>
     <jsp:include page="partials/PressureBlock.jsp">
       <jsp:param name="title" value="Lecturas de presiones de operación de comedor"/>
+      <jsp:param name="base" value="comedor"/>
     </jsp:include>
 
     <%-- Pressure: Baños --%>
     <jsp:include page="partials/PressureBlock.jsp">
       <jsp:param name="title" value="Lecturas de presiones de operación de baños"/>
+      <jsp:param name="base" value="banos"/>
     </jsp:include>
 
   </div>

--- a/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/OperationBlock.jsp
@@ -3,7 +3,8 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ include file="../loadData.jspf" %>
-<c:set var="base" value="${fn:replace(param.title,' ','_')}" />
+<c:set var="savedData" value="${requestScope.savedData}" />
+<c:set var="base" value="${not empty param.base ? param.base : fn:replace(param.title,' ','_')}" />
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
 <div>

--- a/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
+++ b/jsp/checklist/aireCondicionado/partials/PressureBlock.jsp
@@ -2,7 +2,8 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ include file="../loadData.jspf" %>
-<c:set var="base" value="${fn:replace(param.title,' ','_')}" />
+<c:set var="savedData" value="${requestScope.savedData}" />
+<c:set var="base" value="${not empty param.base ? param.base : fn:replace(param.title,' ','_')}" />
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
 <div>

--- a/jsp/checklist/refrigeracion/OperationReadings.jsp
+++ b/jsp/checklist/refrigeracion/OperationReadings.jsp
@@ -1,5 +1,7 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ include file="loadData.jspf" %>
+<c:set var="savedData" value="${requestScope.savedData}" />
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
 <div class="mb-8">
@@ -12,33 +14,33 @@
         <tbody>
           <tr>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_voltage_ab" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_voltage_bc" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_voltage_ca" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_voltage_ab" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['cons_voltage_ab']}"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_voltage_bc" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['cons_voltage_bc']}"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_voltage_ca" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['cons_voltage_ca']}"/></td>
           </tr>
           <tr class="bg-gray-50">
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_amp_a" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_amp_b" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_amp_c" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_amp_a" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['cons_amp_a']}"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_amp_b" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['cons_amp_b']}"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_amp_c" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['cons_amp_c']}"/></td>
           </tr>
           <tr>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Superheat compresor</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_superheat" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_superheat" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['cons_superheat']}"/></td>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Temp. Inyeccion</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_temp_inyeccion" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_temp_inyeccion" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['cons_temp_inyeccion']}"/></td>
           </tr>
           <tr class="bg-gray-50">
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Temp. Succion</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_temp_succion" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="cons_temp_succion" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['cons_temp_succion']}"/></td>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Temp. Retorno</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_temp_retorno" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_temp_retorno" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['cons_temp_retorno']}"/></td>
           </tr>
           <tr>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Medicion de presion (ALTA)    PSI</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['cons_presion_alta']}"/></td>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Medicion de presion (BAJA)    PSI</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="cons_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['cons_presion_baja']}"/></td>
           </tr>
         </tbody>
       </table>
@@ -52,33 +54,33 @@
         <tbody>
           <tr>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Voltage</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_voltage_ab" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_voltage_bc" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_voltage_ca" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_voltage_ab" placeholder="AB" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['free_voltage_ab']}"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_voltage_bc" placeholder="BC" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['free_voltage_bc']}"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_voltage_ca" placeholder="CA" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['free_voltage_ca']}"/></td>
           </tr>
           <tr class="bg-gray-50">
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Amperage</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_amp_a" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_amp_b" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_amp_c" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_amp_a" placeholder="A" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['free_amp_a']}"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_amp_b" placeholder="B" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['free_amp_b']}"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_amp_c" placeholder="C" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['free_amp_c']}"/></td>
           </tr>
           <tr>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Superheat compresor</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_superheat" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_superheat" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['free_superheat']}"/></td>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Temp. Inyeccion</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_temp_inyeccion" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_temp_inyeccion" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['free_temp_inyeccion']}"/></td>
           </tr>
           <tr class="bg-gray-50">
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Temp. Succion</td>
-            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_temp_succion" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-r border-gray-300"><input type="number" name="free_temp_succion" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['free_temp_succion']}"/></td>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Temp. Retorno</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_temp_retorno" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_temp_retorno" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['free_temp_retorno']}"/></td>
           </tr>
           <tr>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Medicion de presion (ALTA)    PSI</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_presion_alta" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['free_presion_alta']}"/></td>
             <td class="py-2 px-4 border-b border-r border-gray-300 text-sm font-medium text-gray-700">Medicion de presion (BAJA)    PSI</td>
-            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500"/></td>
+            <td class="py-2 px-2 border-b border-gray-300"><input type="number" name="free_presion_baja" class="w-full text-center border-gray-300 rounded-sm focus:border-blue-500 focus:ring-blue-500" value="${savedData['free_presion_baja']}"/></td>
           </tr>
         </tbody>
       </table>

--- a/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/OperationBlock.jsp
@@ -3,7 +3,8 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ include file="../loadData.jspf" %>
-<c:set var="base" value="${fn:replace(param.title,' ','_')}" />
+<c:set var="savedData" value="${requestScope.savedData}" />
+<c:set var="base" value="${not empty param.base ? param.base : fn:replace(param.title,' ','_')}" />
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
 <div>

--- a/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
+++ b/jsp/checklist/refrigeracion/partials/PressureBlock.jsp
@@ -2,7 +2,8 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ include file="../loadData.jspf" %>
-<c:set var="base" value="${fn:replace(param.title,' ','_')}" />
+<c:set var="savedData" value="${requestScope.savedData}" />
+<c:set var="base" value="${not empty param.base ? param.base : fn:replace(param.title,' ','_')}" />
 <link rel="stylesheet" href="<%= request.getContextPath() %>/assets/css/checklist.css">
 
 <div>


### PR DESCRIPTION
## Summary
- Pass explicit field prefixes from OperationReadings to operation and pressure blocks
- Allow operation and pressure block partials to prefer provided prefixes over titles when resolving saved values
- Populate refrigeration OperationReadings inputs from the saved data map

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689acd9480dc8332bcfdb010854a5be4