### PR TITLE
Allow preventive maintenance submission without technical data

### DIFF
--- a/jsp/formTerminar.jsp
+++ b/jsp/formTerminar.jsp
@@ -77,7 +77,7 @@
 <div class="col-xs-12" style="padding-top: 5px;">
 <div class="row">
 <div class="col-xs-2">Domicilio:</div>
-	<div class="col-xs-4"><input type="text" id="frmdireccion" style="width:100%;" class="form-control"  placeholder="nombre de la dirección" value="<%=registro.getString("domicilio")%>"/></div>
+	<div class="col-xs-4"><input type="text" id="frmdireccion" style="width:100%;" class="form-control"  placeholder="nombre de la direcciÃ³n" value="<%=registro.getString("domicilio")%>"/></div>
 	<div class="col-xs-2">Ciudad:</div>
 	<div class="col-xs-4"><input type="text" id="frmciudad" style="width:100%;" class="form-control"  placeholder="nombre de la ciudad" value="<%=registro.getString("ciudad")%>"/></div>
 	
@@ -130,9 +130,9 @@
 <div class="col-xs-12" style="padding-top: 25px;">
 <div class="row">
 	<div class="col-xs-2">Recibido por:</div>
-	<div class="col-xs-4"><input type="text" disabled id="recibidopor" style="width:100%;" class="form-control"  placeholder="Nombre de quien recibió" value="<%=registro.getString("RecibidoPorNombre")%>"/></div>
+	<div class="col-xs-4"><input type="text" disabled id="recibidopor" style="width:100%;" class="form-control"  placeholder="Nombre de quien recibiÃ³" value="<%=registro.getString("RecibidoPorNombre")%>"/></div>
 	<div class="col-xs-2">Puesto:</div>
-	<div class="col-xs-4"><input type="text" disabled id="puestorecibido" style="width:100%;" class="form-control"  placeholder="Puesto de quien recibió" value="<%=registro.getString("RecibidoPorPuesto")%>"/></div>
+	<div class="col-xs-4"><input type="text" disabled id="puestorecibido" style="width:100%;" class="form-control"  placeholder="Puesto de quien recibiÃ³" value="<%=registro.getString("RecibidoPorPuesto")%>"/></div>
 </div>
 </div>
 <div class="col-xs-12" style="padding-top: 5px;">
@@ -219,7 +219,7 @@
 	<div class="col-xs-2"><input type="text" id="cond2" style="width:100%;" class="form-control"  placeholder="psi"/></div>
 	<div class="col-xs-2">Temperatura de Operaci&oacute;n:</div>
 	<div class="col-xs-2"><input type="text" id="tempopera" style="width:100%;" class="form-control"  placeholder=""/></div>
-	<div class="col-xs-2"><input type="radio" name="tempounidad" value="C"/> <label style="display:inline-block;">°C</label> &nbsp;&nbsp;&nbsp;<input type="radio" name="tempounidad" value="F" /> °F</div>
+	<div class="col-xs-2"><input type="radio" name="tempounidad" value="C"/> <label style="display:inline-block;">Â°C</label> &nbsp;&nbsp;&nbsp;<input type="radio" name="tempounidad" value="F" /> Â°F</div>
 
 </div>
 </div>
@@ -315,6 +315,14 @@
                                 var cliente = encodeURIComponent($('#frmcliente').val());
                                 $('#tabAire').attr('src', '../maintenance-form?orden=' + orden + '&cliente=' + cliente);
                                 $('#tabRefrigeracion').attr('src', '../refrigeracion-form?orden=' + orden + '&cliente=' + cliente);
+                                $('#aceptarform').on('mousedown', function(){
+                                        $('#marca, #serie, #modelo, #comentarios, #cond1, #cond2, #tenicoserv').val('NA');
+                                        $('#voltaje, #amperes, #tempopera, #voltaje2, #amperes2').val('0');
+                                        $('#servreal').prop('selectedIndex',1);
+                                        $('#nombreequipo').prop('selectedIndex',1);
+                                        $('input[name=servterminado]').first().prop('checked',true);
+                                        $('input[name=tempounidad]').first().prop('checked',true);
+                                });
                         }
 
                         $('#tabAireLink').on('click', function(e){

--- a/jsp/formTerminarMovil.jsp
+++ b/jsp/formTerminarMovil.jsp
@@ -105,7 +105,7 @@
 <div class="col-xs-4">Domicilio:</div>
 	<div class="col-xs-8">
 	<textarea disabled class="form-control" rows="5" id="frmdireccion" style="width:100%;" ><%=registro.getString("domicilio")%></textarea>
-<%-- 	<input type="text" id="frmdireccion" style="width:100%;" class="form-control"  placeholder="nombre de la dirección" value="<%=registro.getString("domicilio")%>"/> --%>
+<%-- 	<input type="text" id="frmdireccion" style="width:100%;" class="form-control"  placeholder="nombre de la direcciÃ³n" value="<%=registro.getString("domicilio")%>"/> --%>
 	</div>
 </div>
 </div>
@@ -171,7 +171,7 @@
 <div class="col-xs-12" style="padding-top: 5px;">
 <div class="row">
 	<div class="col-xs-4">Recibido por:</div>
-	<div class="col-xs-8"><input type="text" disabled id="recibidopor" style="width:100%;" class="form-control"  placeholder="Nombre de quien recibió" value="<%=registro.getString("RecibidoPorNombre")%>"/></div>
+	<div class="col-xs-8"><input type="text" disabled id="recibidopor" style="width:100%;" class="form-control"  placeholder="Nombre de quien recibiÃ³" value="<%=registro.getString("RecibidoPorNombre")%>"/></div>
 	
 </div>
 </div>
@@ -179,7 +179,7 @@
 <div class="col-xs-12" style="padding-top: 5px;">
 <div class="row">
 	<div class="col-xs-4">Puesto:</div>
-	<div class="col-xs-8"><input type="text" disabled id="puestorecibido" style="width:100%;" class="form-control"  placeholder="Puesto de quien recibió" value="<%=registro.getString("RecibidoPorPuesto")%>"/></div>
+	<div class="col-xs-8"><input type="text" disabled id="puestorecibido" style="width:100%;" class="form-control"  placeholder="Puesto de quien recibiÃ³" value="<%=registro.getString("RecibidoPorPuesto")%>"/></div>
 </div>
 </div>
 <div class="col-xs-12" style="padding-top: 5px;">
@@ -289,7 +289,7 @@
 <div class="row">
 	<div class="col-xs-4">Temp. de Operaci&oacute;n:</div>
 	<div class="col-xs-4"><input type="text" id="tempopera" style="width:100%;" class="form-control"  placeholder=""/></div>
-	<div class="col-xs-4"><input type="radio" name="tempounidad" value="C"/> <label style="display:inline-block;">°C</label> &nbsp;&nbsp;&nbsp;<input type="radio" name="tempounidad" value="F" /> °F</div>
+	<div class="col-xs-4"><input type="radio" name="tempounidad" value="C"/> <label style="display:inline-block;">Â°C</label> &nbsp;&nbsp;&nbsp;<input type="radio" name="tempounidad" value="F" /> Â°F</div>
 
 </div>
 </div>
@@ -536,20 +536,31 @@
 				$("#frmciudad").attr('disabled','disabled'); 
 				
 			}
-			else
-			{
-				$("#frmordenServicio").attr('disabled','disabled');
-				$("#frmcliente").attr('disabled','disabled'); 
-				$("#frmdireccion").attr('disabled','disabled'); 
-				$("#frmciudad").attr('disabled','disabled'); 
-				$("#frmsucu").attr('disabled','disabled'); 
-				$("#frmgerente").attr('disabled','disabled'); 
-				$("#frmtipomantenimiento").attr('disabled','disabled'); 
-				$("#frmultimotec").attr('disabled','disabled'); 
-			}
+                        else
+                        {
+                                $("#frmordenServicio").attr('disabled','disabled');
+                                $("#frmcliente").attr('disabled','disabled');
+                                $("#frmdireccion").attr('disabled','disabled');
+                                $("#frmciudad").attr('disabled','disabled');
+                                $("#frmsucu").attr('disabled','disabled');
+                                $("#frmgerente").attr('disabled','disabled');
+                                $("#frmtipomantenimiento").attr('disabled','disabled');
+                                $("#frmultimotec").attr('disabled','disabled');
+                        }
 
-		
-		 consultaFacturas("C");
+                        if($('#formtecnico').is(':hidden') && $('#frmtipomantenimiento').val() === 'PREVENTIVO'){
+                                $('#aceptarform').on('mousedown', function(){
+                                        $('#marca, #serie, #modelo, #comentarios, #cond1, #cond2, #tenicoserv').val('NA');
+                                        $('#voltaje, #amperes, #tempopera, #voltaje2, #amperes2').val('0');
+                                        $('#servreal').prop('selectedIndex',1);
+                                        $('#nombreequipo').prop('selectedIndex',1);
+                                        $('input[name=servterminado]').first().prop('checked',true);
+                                        $('input[name=tempounidad]').first().prop('checked',true);
+                                });
+                        }
+
+
+                 consultaFacturas("C");
 		 $("#otroNombreEquipo").attr('maxlength','50');
 		 $("#marca").attr('maxlength','50');
 		 $("#modelo").attr('maxlength','50');


### PR DESCRIPTION
## Summary
- Auto-fill hidden technical fields when preventive maintenance is selected so required checks pass
- Apply same behavior for mobile termination form

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bb3810a4c8332891b48e0d38183f0