### PR TITLE
Allow preventive maintenance tasks to skip validation

### DIFF
--- a/jsp/tareas.jsp
+++ b/jsp/tareas.jsp
@@ -171,7 +171,7 @@
 		<div class="col-xs-9">
 			<div class="row">
 			<div class="col-xs-12 col-sm-6">
-<!-- 				<input type="text" id="rango1" style="width:100%;" class="form-control" maxlength="4" placeholder="Mínimo"/> -->
+<!-- 				<input type="text" id="rango1" style="width:100%;" class="form-control" maxlength="4" placeholder="MÃ­nimo"/> -->
 				<div class='input-group date' id='fechainicio'>
                     <input type='text' class="form-control" />
                     <span class="input-group-addon">
@@ -180,7 +180,7 @@
                 </div>
 			</div>
 			<div class="col-xs-12 col-sm-6">
-<!-- 				<input type="text" id="rango2" style="width:100%;" class="form-control" maxlength="4" placeholder="Máximo"/> -->
+<!-- 				<input type="text" id="rango2" style="width:100%;" class="form-control" maxlength="4" placeholder="MÃ¡ximo"/> -->
 				<div class='input-group date' id='fechafin'>
                     <input type='text' class="form-control" />
                     <span class="input-group-addon">
@@ -287,18 +287,18 @@
 // 	            filteringType: "local",
 // 	            filteringCondition: "contains",
 // 	            highlightMatchesMode: "contains",
-// 	            placeHolder: "Buscar técnico...",
+// 	            placeHolder: "Buscar tÃ©cnico...",
 // 	            dropDownOrientation: "bottom"
 // // 	         	selectionChanged: storeTecnicos
 // 	        });
 // 		$("#selectTecnicoR").select2({
 // 			data:storeTecnicos,
-// 			placeholder: "Seleccione Técnico"
+// 			placeholder: "Seleccione TÃ©cnico"
 // 		});
 		
 // 		$("#selectTecnicoActual").select2({
 // 			data:storeTecnicoActual,
-// 			placeholder: "Seleccione Técnico"
+// 			placeholder: "Seleccione TÃ©cnico"
 // 		});
 
 		$('#fechainicio').datetimepicker(
@@ -477,7 +477,7 @@
     /**********************************************************************/ 
     function abrirASIGNAR(foliopisa,telefono,folioplex,expediente)
     {
-    	// En el parametro estado se le envia el estado en el que fue levantada la acción
+    	// En el parametro estado se le envia el estado en el que fue levantada la acciÃ³n
     	var parametros="";
     	if(tipoAccion == ""){
     		tipoAccion="Asignar";
@@ -507,7 +507,7 @@
     		  					if(resp.trim() == "COMPLETE"){
     		  						resp="LIQUIDADA";
     		  					}
-    		  					swal("", "No se pudo realizo la acción porque la tarea ya esta " + resp+".", "error");
+    		  					swal("", "No se pudo realizo la acciÃ³n porque la tarea ya esta " + resp+".", "error");
     		  					cargaTareas();
     		  				}
     		  				tipoAccion="";
@@ -528,7 +528,7 @@
             height: 400,
             width: 500,
             modal: true,
-            title: "Reasignación de Tarea",
+            title: "ReasignaciÃ³n de Tarea",
             buttons: [{
               text : "Aceptar",
               "class": "btn btn-primary",
@@ -540,13 +540,13 @@
   	  			if(expedienteNuevo!="" && expedienteNuevo!=undefined)
   	  			{
   	    	swal({
-  	    		title: "",  
-  	    		text: "¿Desea asignar la orden "+foliopisa+" al tecnico "+nombre+"?",     
-      			type: "info",   
-      			showCancelButton: true,   
+  	    		title: "",Â Â 
+  	    		text: "Â¿Desea asignar la orden "+foliopisa+" al tecnico "+nombre+"?", Â Â Â Â 
+      			type: "info", Â Â 
+      			showCancelButton: true, Â Â 
       			cancelButtonText: "Cancelar",
-      			confirmButtonColor: "#3a5a74",   
-      			confirmButtonText: "Aceptar",   
+      			confirmButtonColor: "#3a5a74", Â Â 
+      			confirmButtonText: "Aceptar", Â Â 
       			closeOnConfirm: false }, 
       			function(){
        				$.ajax({
@@ -558,12 +558,12 @@
                  				{
 			                 				
 			                 				swal({
-				            	    		title: "",  
-				            	    		text: "La asignación de tarea(s) fue satisfactoria.",   
-				                			type: "success",   
-				                			showCancelButton: false,   
-				                			confirmButtonColor: "#3a5a74",   
-				                			confirmButtonText: "Aceptar",   
+				            	    		title: "",Â Â 
+				            	    		text: "La asignaciÃ³n de tarea(s) fue satisfactoria.", Â Â 
+				                			type: "success", Â Â 
+				                			showCancelButton: false, Â Â 
+				                			confirmButtonColor: "#3a5a74", Â Â 
+				                			confirmButtonText: "Aceptar", Â Â 
 				                			closeOnConfirm: true }, 
 				                			function(){
 				                				//Borrar tarea del panel de Tareas
@@ -586,7 +586,7 @@
   	  }
   	  else
   		  {
-  		  swal("Debe seleccionar un técnico", "", "warning");
+  		  swal("Debe seleccionar un tÃ©cnico", "", "warning");
   		  }
 //             	  var expediente=$("#selectTecnico").find("option:selected").val();
 //             	  var nombre=$("#selectTecnicoR").find("option:selected").text();
@@ -595,13 +595,13 @@
 //             	  if(expediente!="")
 //             	  {
 //             	    	swal({
-//             	    		title: "",  
-//             	    		text: "Desea asignar la order "+folioplex+" al tecnico "+nombre+"?",    
-//                 			type: "info",   
-//                 			showCancelButton: true,   
+//             	    		title: "",Â Â 
+//             	    		text: "Desea asignar la order "+folioplex+" al tecnico "+nombre+"?", Â Â Â 
+//                 			type: "info", Â Â 
+//                 			showCancelButton: true, Â Â 
 //                 			cancelButtonText: "Cancelar",
-//                 			confirmButtonColor: "#3a5a74",   
-//                 			confirmButtonText: "Aceptar",   
+//                 			confirmButtonColor: "#3a5a74", Â Â 
+//                 			confirmButtonText: "Aceptar", Â Â 
 //                 			closeOnConfirm: true }, 
 //                 			function(){
 //                         				$.ajax({
@@ -660,7 +660,7 @@
 //             	  }
 //             	  else
 //             		  {
-//             		  swal("Debe seleccionar un técnico", "", "warning");
+//             		  swal("Debe seleccionar un tÃ©cnico", "", "warning");
 //             		  }
             	  
             	  }
@@ -687,16 +687,16 @@
 							if(resp.trim()=="OK")
     		  				{
     		  					swal({
-					    		title: "",  
-					    		text: "¿Desea despachar la orden: "+foliopisa+"?",      
-					    			type: "info",   
-					    			showCancelButton: true,   
+					    		title: "",Â Â 
+					    		text: "Â¿Desea despachar la orden: "+foliopisa+"?", Â Â  Â Â 
+					    			type: "info", Â Â 
+					    			showCancelButton: true, Â Â 
 					    			cancelButtonText: "Cancelar",
-					    			confirmButtonColor: "#3a5a74",    
-					    			confirmButtonText: "Aceptar",   
+					    			confirmButtonColor: "#3a5a74", Â Â Â 
+					    			confirmButtonText: "Aceptar", Â Â 
 					    			closeOnConfirm: true }, 
 					    			function(){
-					    				  var parametros="estado=DESPACHADA&tipo=DESPACHADA&folioplex="+folioplex+"&foliopisa="+foliopisa;
+					    				Â Â var parametros="estado=DESPACHADA&tipo=DESPACHADA&folioplex="+folioplex+"&foliopisa="+foliopisa;
 					    		    	$.ajax({
 					    		  			url: 'actualizaEstado.jsp?'+parametros,
 					    		  			type: "GET",
@@ -810,7 +810,7 @@
         autoOpen: false,
         height: 400,
         width: 350,
-        title: "Liquidación",
+        title: "LiquidaciÃ³n",
         modal: true
         });
     
@@ -871,7 +871,7 @@
     /***********************************/  
     function abrirOBJETAR(foliopisa,telefono,folioplex,expediente,estado)
     {
-		// En el parametro estado se le envia el estado en el que fue levantada la acción
+		// En el parametro estado se le envia el estado en el que fue levantada la acciÃ³n
     	var parametros = "folioplex="+folioplex+"&estado=DESPACHADA";
   		$.ajax({
 		url: "../ValidarEstadoTarea?"+parametros,
@@ -888,7 +888,7 @@
 	  					if(resp.trim() == "COMPLETE"){
 	  						resp="LIQUIDADA";
 	  					}
-	  					swal("", "No se pudo realizo la acción porque la tarea ya esta " + resp+".", "error");
+	  					swal("", "No se pudo realizo la acciÃ³n porque la tarea ya esta " + resp+".", "error");
 	  					cargaTareas();
 		  			}
 				}
@@ -907,13 +907,13 @@
   		  	{
     	
 		    	swal({
-		    		title: "",  
-		    		text: "¿Desea liquidar la orden: "+foliopisa+"?",   
-	    			type: "info",   
-	    			showCancelButton: true,   
+		    		title: "",Â Â 
+		    		text: "Â¿Desea liquidar la orden: "+foliopisa+"?", Â Â 
+	    			type: "info", Â Â 
+	    			showCancelButton: true, Â Â 
 	    			cancelButtonText: "Cancelar",
-	    			confirmButtonColor: "#3a5a74",    
-	    			confirmButtonText: "Liquidar",   
+	    			confirmButtonColor: "#3a5a74", Â Â Â 
+	    			confirmButtonText: "Liquidar", Â Â 
 	    			closeOnConfirm: true }, 
 	    			function(){
 	    				var parametros="estado=COMPLETE&tipo=COMPLETE&folioplex="+folioplex+"&foliopisa="+foliopisa;
@@ -1138,12 +1138,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Incidencia Capturada!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Incidencia Capturada!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1208,7 +1208,7 @@
     	var tituloform = "";
     	var alto = 0;
 
-    		tituloform = "Reasignar Técnico";
+    		tituloform = "Reasignar TÃ©cnico";
     		alto=h-150;
     		
     		if(w<600)
@@ -1261,12 +1261,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Incidencia Asignada!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Incidencia Asignada!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1324,7 +1324,7 @@
     	var tituloform = "";
     	var alto = 0;
 
-    		tituloform = "Asignar Técnico";
+    		tituloform = "Asignar TÃ©cnico";
     		alto=h-150;
     		if(w<600)
     		{
@@ -1374,12 +1374,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Incidencia Asignada!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Incidencia Asignada!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1487,12 +1487,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Trabajo en Curso!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Trabajo en Curso!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1578,52 +1578,53 @@
  	        		text: "Aceptar", 
  	        		click:    function() {
  	        			var bandvalida = true;
- 	        			var parmarca = $("#marca").val();
- 	        			if(parmarca==""){$("#sec-marca").addClass("has-error"); bandvalida=false;}else{$("#sec-marca").removeClass("has-error");}
+                                        var skipValidation = $("#formtecnico").is(':hidden') && $("#frmtipomantenimiento").val() === 'PREVENTIVO';
+                                        var parmarca = $("#marca").val();
+ 	        			if(parmarca=="" && !skipValidation){$("#sec-marca").addClass("has-error"); bandvalida=false;}else{$("#sec-marca").removeClass("has-error");}
  	        			var parserie = $("#serie").val();  
 //  	        			if(parserie==""){$("#sec-serie").addClass("has-error"); bandvalida=false;}else{$("#sec-serie").removeClass("has-error");}
  	        			var parmodelo = $("#modelo").val();  
 //  	        			if(parmodelo==""){$("#sec-modelo").addClass("has-error"); bandvalida=false;}else{$("#sec-modelo").removeClass("has-error");}
  	        			var parvoltaje = $("#voltaje").val();  
- 	        			if(parvoltaje==""){$("#sec-parvoltaje").addClass("has-error"); bandvalida=false;}else{$("#sec-parvoltaje").removeClass("has-error");}
+ 	        			if(parvoltaje=="" && !skipValidation){$("#sec-parvoltaje").addClass("has-error"); bandvalida=false;}else{$("#sec-parvoltaje").removeClass("has-error");}
  	        			var paramperes = $("#amperes").val(); 
- 	        			if(paramperes==""){$("#sec-amperes").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes").removeClass("has-error");}
+ 	        			if(paramperes=="" && !skipValidation){$("#sec-amperes").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes").removeClass("has-error");}
 //  	        			var parrazonserv = $("#razonserv").val();  
  	        			var parservreal = $("#servreal option:selected").text();
- 	        			if(parservreal=="Seleccionar..."){$("#sec-servreal").addClass("has-error"); bandvalida=false;}else{$("#sec-servreal").removeClass("has-error");}
+ 	        			if(parservreal=="Seleccionar..." && !skipValidation){$("#sec-servreal").addClass("has-error"); bandvalida=false;}else{$("#sec-servreal").removeClass("has-error");}
  	        			var bandservreal = "";
  	        			if(parservreal=="OTRO")
  	        			{
  	        				bandservreal ="S";
  	        				parservreal=$("#otroServicioReal").val();  
- 	        				if(servreal==""){$("#sec-otroServicioReal").addClass("has-error"); bandvalida=false;}else{$("#sec-otroServicioReal").removeClass("has-error");}
+ 	        				if(servreal=="" && !skipValidation){$("#sec-otroServicioReal").addClass("has-error"); bandvalida=false;}else{$("#sec-otroServicioReal").removeClass("has-error");}
  	        			}
  	        			var parcomentarios = $("#comentarios").val();  
- 	        			if(parcomentarios==""){$("#sec-comentarios").addClass("has-error"); bandvalida=false;}else{$("#sec-comentarios").removeClass("has-error");}
+ 	        			if(parcomentarios=="" && !skipValidation){$("#sec-comentarios").addClass("has-error"); bandvalida=false;}else{$("#sec-comentarios").removeClass("has-error");}
  	        			var parcon1 = $("#cond1").val(); 
- 	        			if(parcon1==""){$("#sec-cond1").addClass("has-error"); bandvalida=false;}else{$("#sec-cond1").removeClass("has-error");}
+ 	        			if(parcon1=="" && !skipValidation){$("#sec-cond1").addClass("has-error"); bandvalida=false;}else{$("#sec-cond1").removeClass("has-error");}
 	 	   				var parcon2 = $("#cond2").val();  
-	 	   				if(parcon2==""){$("#sec-cond2").addClass("has-error"); bandvalida=false;}else{$("#sec-cond2").removeClass("has-error");}
+	 	   				if(parcon2=="" && !skipValidation){$("#sec-cond2").addClass("has-error"); bandvalida=false;}else{$("#sec-cond2").removeClass("has-error");}
 	 	   				var partempopera = $("#tempopera").val();  
-	 	   				if(partempopera==""){$("#sec-tempopera").addClass("has-error"); bandvalida=false;}else{$("#sec-tempopera").removeClass("has-error");}
+	 	   				if(partempopera=="" && !skipValidation){$("#sec-tempopera").addClass("has-error"); bandvalida=false;}else{$("#sec-tempopera").removeClass("has-error");}
 	 	   				var parvoltaje2 = $("#voltaje2").val(); 
-	 	   				if(parvoltaje2==""){$("#sec-voltaje2").addClass("has-error"); bandvalida=false;}else{$("#sec-voltaje2").removeClass("has-error");}
+	 	   				if(parvoltaje2=="" && !skipValidation){$("#sec-voltaje2").addClass("has-error"); bandvalida=false;}else{$("#sec-voltaje2").removeClass("has-error");}
 	 	   				var paramperes2 = $("#amperes2").val();
-	 	   				if(paramperes2==""){$("#sec-amperes2").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes2").removeClass("has-error");}
+	 	   				if(paramperes2=="" && !skipValidation){$("#sec-amperes2").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes2").removeClass("has-error");}
 	 	   				var partenicoserv = $("#tenicoserv").val();
 // 	 	   				if(partenicoserv==""){$("#sec-tenicoserv").addClass("has-error"); bandvalida=false;}else{$("#sec-tenicoserv").removeClass("has-error");}
 	 	   				var parnombreequipo =$("#nombreequipo option:selected").text();
-	 	   				if(parnombreequipo=="Seleccionar..."){$("#sec-nombreequipo").addClass("has-error"); bandvalida=false;}else{$("#sec-nombreequipo").removeClass("has-error");}
+	 	   				if(parnombreequipo=="Seleccionar..." && !skipValidation){$("#sec-nombreequipo").addClass("has-error"); bandvalida=false;}else{$("#sec-nombreequipo").removeClass("has-error");}
 	 	   				var bandEquipo ="";
 	 	   				if(parnombreequipo=="OTRO")
 	 	   				{
 	 	   				bandEquipo= "S";
 	 	   				parnombreequipo =$("#otroNombreEquipo").val();
-	 	   				if(parnombreequipo==""){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
+	 	   				if(parnombreequipo=="" && !skipValidation){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
 	 	   				}
 	 	   				var parservterminado = $('input[name=servterminado]:checked').val();
 	 	   				var partempounidad = $('input[name=tempounidad]:checked').val();
-	 	   				if(partempounidad==undefined){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
+	 	   				if(partempounidad==undefined && !skipValidation){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
 	 	   			    if(parservterminado==undefined){parservterminado=""}
  	        			var param = "accion=TERMINAR";
  	        			param += "&orden="+escape(idorden)+"&marca="+escape(parmarca)+"&serie="+escape(parserie)+"&modelo="+escape(parmodelo)+"&voltaje="+escape(parvoltaje)+"&amperes="+escape(paramperes)+"&servreal="+escape(parservreal)+"&comentarios="+escape(parcomentarios);
@@ -1651,12 +1652,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Trabajo Terminado!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Trabajo Terminado!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1779,12 +1780,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Trabajo Suspendido!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Trabajo Suspendido!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1843,13 +1844,13 @@
     function realizaREANUDAR(idorden,ordenserv, sigestatus,actualestatus,idaccion)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea reanudar el trabajo "+ordenserv+"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea reanudar el trabajo "+ordenserv+"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Cancelar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   				var param="accion=REANUDAR";
@@ -1875,12 +1876,12 @@
 										if(item.resp=="OK")
 										{
 											swal({
-					            	    		title: "",  
-					            	    		text: "Trabajo Reanudado!.",   
-					                			type: "success",   
-					                			showCancelButton: false,   
-					                			confirmButtonColor: "#3a5a74",   
-					                			confirmButtonText: "Aceptar",   
+					            	    		title: "",Â Â 
+					            	    		text: "Trabajo Reanudado!.", Â Â 
+					                			type: "success", Â Â 
+					                			showCancelButton: false, Â Â 
+					                			confirmButtonColor: "#3a5a74", Â Â 
+					                			confirmButtonText: "Aceptar", Â Â 
 					                			closeOnConfirm: true }, 
 					                			function(){
 					                				cargaTareas();
@@ -1909,13 +1910,13 @@
     function realizaCERRAR(idorden,ordenserv,sigestatus,actualestatus,idaccion)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea cerrar el trabajo "+ordenserv+"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea cerrar el trabajo "+ordenserv+"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Cancelar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   			
@@ -1942,12 +1943,12 @@
 										if(item.resp=="OK")
 										{
 											swal({
-					            	    		title: "",  
-					            	    		text: "Trabajo Cerrado!.",   
-					                			type: "success",   
-					                			showCancelButton: false,   
-					                			confirmButtonColor: "#3a5a74",   
-					                			confirmButtonText: "Aceptar",   
+					            	    		title: "",Â Â 
+					            	    		text: "Trabajo Cerrado!.", Â Â 
+					                			type: "success", Â Â 
+					                			showCancelButton: false, Â Â 
+					                			confirmButtonColor: "#3a5a74", Â Â 
+					                			confirmButtonText: "Aceptar", Â Â 
 					                			closeOnConfirm: true }, 
 					                			function(){
 					                				cargaTareas();
@@ -1977,13 +1978,13 @@
     function realizaELIMINAR(idorden,ordenserv,sigestatus,actualestatus,idaccion)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea eliminar el trabajo "+ordenserv+"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea eliminar el trabajo "+ordenserv+"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Eliminar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   			
@@ -2010,12 +2011,12 @@
 										if(item.resp=="OK")
 										{
 											swal({
-					            	    		title: "",  
-					            	    		text: "Trabajo Eliminado!.",   
-					                			type: "success",   
-					                			showCancelButton: false,   
-					                			confirmButtonColor: "#3a5a74",   
-					                			confirmButtonText: "Aceptar",   
+					            	    		title: "",Â Â 
+					            	    		text: "Trabajo Eliminado!.", Â Â 
+					                			type: "success", Â Â 
+					                			showCancelButton: false, Â Â 
+					                			confirmButtonColor: "#3a5a74", Â Â 
+					                			confirmButtonText: "Aceptar", Â Â 
 					                			closeOnConfirm: true }, 
 					                			function(){
 					                				cargaTareas();
@@ -2100,12 +2101,12 @@
  	   										{
  	   										$("#container").mLoading("hide");
  	   											swal({
- 	   					            	    		title: "",  
- 	   					            	    		text: "El trabajo ya puede ser terminado!.",   
- 	   					                			type: "success",   
- 	   					                			showCancelButton: false,   
- 	   					                			confirmButtonColor: "#3a5a74",   
- 	   					                			confirmButtonText: "Aceptar",   
+ 	   					            	    		title: "",Â Â 
+ 	   					            	    		text: "El trabajo ya puede ser terminado!.", Â Â 
+ 	   					                			type: "success", Â Â 
+ 	   					                			showCancelButton: false, Â Â 
+ 	   					                			confirmButtonColor: "#3a5a74", Â Â 
+ 	   					                			confirmButtonText: "Aceptar", Â Â 
  	   					                			closeOnConfirm: true }, 
  	   					                			function(){
  	   					                				modaldialog.dialog( "close" ); 
@@ -2132,7 +2133,7 @@
  	        			}
  	        			else
  	        			{
- 	        				swal("", "Debe seleccionar la confirmación para autorizar!", "error");
+ 	        				swal("", "Debe seleccionar la confirmaciÃ³n para autorizar!", "error");
  	        			}
  	        			
  	        			},
@@ -2227,13 +2228,13 @@
     function eliminarfactura(idfactura, foliofactura, proveedor)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea eliminar la factura \""+foliofactura+"\" del proveedor \""+proveedor+"\"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea eliminar la factura \""+foliofactura+"\" del proveedor \""+proveedor+"\"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Cancelar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   				param="accion=ELIMINARFACT&idfactura="+idfactura;

--- a/jsp/tareasCliente.jsp
+++ b/jsp/tareasCliente.jsp
@@ -173,7 +173,7 @@
 		<div class="col-xs-9">
 			<div class="row">
 			<div class="col-xs-12 col-sm-6">
-<!-- 				<input type="text" id="rango1" style="width:100%;" class="form-control" maxlength="4" placeholder="Mínimo"/> -->
+<!-- 				<input type="text" id="rango1" style="width:100%;" class="form-control" maxlength="4" placeholder="MÃ­nimo"/> -->
 				<div class='input-group date' id='fechainicio'>
                     <input type='text' class="form-control" />
                     <span class="input-group-addon">
@@ -182,7 +182,7 @@
                 </div>
 			</div>
 			<div class="col-xs-12 col-sm-6">
-<!-- 				<input type="text" id="rango2" style="width:100%;" class="form-control" maxlength="4" placeholder="Máximo"/> -->
+<!-- 				<input type="text" id="rango2" style="width:100%;" class="form-control" maxlength="4" placeholder="MÃ¡ximo"/> -->
 				<div class='input-group date' id='fechafin'>
                     <input type='text' class="form-control" />
                     <span class="input-group-addon">
@@ -289,18 +289,18 @@
 // 	            filteringType: "local",
 // 	            filteringCondition: "contains",
 // 	            highlightMatchesMode: "contains",
-// 	            placeHolder: "Buscar técnico...",
+// 	            placeHolder: "Buscar tÃ©cnico...",
 // 	            dropDownOrientation: "bottom"
 // // 	         	selectionChanged: storeTecnicos
 // 	        });
 // 		$("#selectTecnicoR").select2({
 // 			data:storeTecnicos,
-// 			placeholder: "Seleccione Técnico"
+// 			placeholder: "Seleccione TÃ©cnico"
 // 		});
 		
 // 		$("#selectTecnicoActual").select2({
 // 			data:storeTecnicoActual,
-// 			placeholder: "Seleccione Técnico"
+// 			placeholder: "Seleccione TÃ©cnico"
 // 		});
 
 		$('#fechainicio').datetimepicker(
@@ -478,7 +478,7 @@
     /**********************************************************************/ 
     function abrirASIGNAR(foliopisa,telefono,folioplex,expediente)
     {
-    	// En el parametro estado se le envia el estado en el que fue levantada la acción
+    	// En el parametro estado se le envia el estado en el que fue levantada la acciÃ³n
     	var parametros="";
     	if(tipoAccion == ""){
     		tipoAccion="Asignar";
@@ -508,7 +508,7 @@
     		  					if(resp.trim() == "COMPLETE"){
     		  						resp="LIQUIDADA";
     		  					}
-    		  					swal("", "No se pudo realizo la acción porque la tarea ya esta " + resp+".", "error");
+    		  					swal("", "No se pudo realizo la acciÃ³n porque la tarea ya esta " + resp+".", "error");
     		  					cargaTareas();
     		  				}
     		  				tipoAccion="";
@@ -529,7 +529,7 @@
             height: 400,
             width: 500,
             modal: true,
-            title: "Reasignación de Tarea",
+            title: "ReasignaciÃ³n de Tarea",
             buttons: [{
               text : "Aceptar",
               "class": "btn btn-primary",
@@ -541,13 +541,13 @@
   	  			if(expedienteNuevo!="" && expedienteNuevo!=undefined)
   	  			{
   	    	swal({
-  	    		title: "",  
-  	    		text: "¿Desea asignar la orden "+foliopisa+" al tecnico "+nombre+"?",     
-      			type: "info",   
-      			showCancelButton: true,   
+  	    		title: "",Â Â 
+  	    		text: "Â¿Desea asignar la orden "+foliopisa+" al tecnico "+nombre+"?", Â Â Â Â 
+      			type: "info", Â Â 
+      			showCancelButton: true, Â Â 
       			cancelButtonText: "Cancelar",
-      			confirmButtonColor: "#3a5a74",   
-      			confirmButtonText: "Aceptar",   
+      			confirmButtonColor: "#3a5a74", Â Â 
+      			confirmButtonText: "Aceptar", Â Â 
       			closeOnConfirm: false }, 
       			function(){
        				$.ajax({
@@ -559,12 +559,12 @@
                  				{
 			                 				
 			                 				swal({
-				            	    		title: "",  
-				            	    		text: "La asignación de tarea(s) fue satisfactoria.",   
-				                			type: "success",   
-				                			showCancelButton: false,   
-				                			confirmButtonColor: "#3a5a74",   
-				                			confirmButtonText: "Aceptar",   
+				            	    		title: "",Â Â 
+				            	    		text: "La asignaciÃ³n de tarea(s) fue satisfactoria.", Â Â 
+				                			type: "success", Â Â 
+				                			showCancelButton: false, Â Â 
+				                			confirmButtonColor: "#3a5a74", Â Â 
+				                			confirmButtonText: "Aceptar", Â Â 
 				                			closeOnConfirm: true }, 
 				                			function(){
 				                				//Borrar tarea del panel de Tareas
@@ -587,7 +587,7 @@
   	  }
   	  else
   		  {
-  		  swal("Debe seleccionar un técnico", "", "warning");
+  		  swal("Debe seleccionar un tÃ©cnico", "", "warning");
   		  }
 //             	  var expediente=$("#selectTecnico").find("option:selected").val();
 //             	  var nombre=$("#selectTecnicoR").find("option:selected").text();
@@ -596,13 +596,13 @@
 //             	  if(expediente!="")
 //             	  {
 //             	    	swal({
-//             	    		title: "",  
-//             	    		text: "Desea asignar la order "+folioplex+" al tecnico "+nombre+"?",    
-//                 			type: "info",   
-//                 			showCancelButton: true,   
+//             	    		title: "",Â Â 
+//             	    		text: "Desea asignar la order "+folioplex+" al tecnico "+nombre+"?", Â Â Â 
+//                 			type: "info", Â Â 
+//                 			showCancelButton: true, Â Â 
 //                 			cancelButtonText: "Cancelar",
-//                 			confirmButtonColor: "#3a5a74",   
-//                 			confirmButtonText: "Aceptar",   
+//                 			confirmButtonColor: "#3a5a74", Â Â 
+//                 			confirmButtonText: "Aceptar", Â Â 
 //                 			closeOnConfirm: true }, 
 //                 			function(){
 //                         				$.ajax({
@@ -661,7 +661,7 @@
 //             	  }
 //             	  else
 //             		  {
-//             		  swal("Debe seleccionar un técnico", "", "warning");
+//             		  swal("Debe seleccionar un tÃ©cnico", "", "warning");
 //             		  }
             	  
             	  }
@@ -688,16 +688,16 @@
 							if(resp.trim()=="OK")
     		  				{
     		  					swal({
-					    		title: "",  
-					    		text: "¿Desea despachar la orden: "+foliopisa+"?",      
-					    			type: "info",   
-					    			showCancelButton: true,   
+					    		title: "",Â Â 
+					    		text: "Â¿Desea despachar la orden: "+foliopisa+"?", Â Â  Â Â 
+					    			type: "info", Â Â 
+					    			showCancelButton: true, Â Â 
 					    			cancelButtonText: "Cancelar",
-					    			confirmButtonColor: "#3a5a74",    
-					    			confirmButtonText: "Aceptar",   
+					    			confirmButtonColor: "#3a5a74", Â Â Â 
+					    			confirmButtonText: "Aceptar", Â Â 
 					    			closeOnConfirm: true }, 
 					    			function(){
-					    				  var parametros="estado=DESPACHADA&tipo=DESPACHADA&folioplex="+folioplex+"&foliopisa="+foliopisa;
+					    				Â Â var parametros="estado=DESPACHADA&tipo=DESPACHADA&folioplex="+folioplex+"&foliopisa="+foliopisa;
 					    		    	$.ajax({
 					    		  			url: 'actualizaEstado.jsp?'+parametros,
 					    		  			type: "GET",
@@ -811,7 +811,7 @@
         autoOpen: false,
         height: 400,
         width: 350,
-        title: "Liquidación",
+        title: "LiquidaciÃ³n",
         modal: true
         });
     
@@ -872,7 +872,7 @@
     /***********************************/  
     function abrirOBJETAR(foliopisa,telefono,folioplex,expediente,estado)
     {
-		// En el parametro estado se le envia el estado en el que fue levantada la acción
+		// En el parametro estado se le envia el estado en el que fue levantada la acciÃ³n
     	var parametros = "folioplex="+folioplex+"&estado=DESPACHADA";
   		$.ajax({
 		url: "../ValidarEstadoTarea?"+parametros,
@@ -889,7 +889,7 @@
 	  					if(resp.trim() == "COMPLETE"){
 	  						resp="LIQUIDADA";
 	  					}
-	  					swal("", "No se pudo realizo la acción porque la tarea ya esta " + resp+".", "error");
+	  					swal("", "No se pudo realizo la acciÃ³n porque la tarea ya esta " + resp+".", "error");
 	  					cargaTareas();
 		  			}
 				}
@@ -908,13 +908,13 @@
   		  	{
     	
 		    	swal({
-		    		title: "",  
-		    		text: "¿Desea liquidar la orden: "+foliopisa+"?",   
-	    			type: "info",   
-	    			showCancelButton: true,   
+		    		title: "",Â Â 
+		    		text: "Â¿Desea liquidar la orden: "+foliopisa+"?", Â Â 
+	    			type: "info", Â Â 
+	    			showCancelButton: true, Â Â 
 	    			cancelButtonText: "Cancelar",
-	    			confirmButtonColor: "#3a5a74",    
-	    			confirmButtonText: "Liquidar",   
+	    			confirmButtonColor: "#3a5a74", Â Â Â 
+	    			confirmButtonText: "Liquidar", Â Â 
 	    			closeOnConfirm: true }, 
 	    			function(){
 	    				var parametros="estado=COMPLETE&tipo=COMPLETE&folioplex="+folioplex+"&foliopisa="+foliopisa;
@@ -1118,12 +1118,12 @@
  											if(item.resp=="OK")
  											{
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Incidencia Capturada!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Incidencia Capturada!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1185,7 +1185,7 @@
     	var tituloform = "";
     	var alto = 0;
 
-    		tituloform = "Reasignar Técnico";
+    		tituloform = "Reasignar TÃ©cnico";
     		alto = 500;
 
     	var modaldialog = $("#dialog").dialog({
@@ -1228,12 +1228,12 @@
  											if(item.resp=="OK")
  											{
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Incidencia Asignada!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Incidencia Asignada!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1287,7 +1287,7 @@
     	var tituloform = "";
     	var alto = 0;
 
-    		tituloform = "Asignar Técnico";
+    		tituloform = "Asignar TÃ©cnico";
     		alto = 500;
 
     	var modaldialog = $("#dialog").dialog({
@@ -1328,12 +1328,12 @@
  											if(item.resp=="OK")
  											{
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Incidencia Asignada!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Incidencia Asignada!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1430,12 +1430,12 @@
  											if(item.resp=="OK")
  											{
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Trabajo en Curso!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Trabajo en Curso!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1585,12 +1585,12 @@
 //  											if(item.resp=="OK")
 //  											{
 //  												swal({
-//  						            	    		title: "",  
-//  						            	    		text: "Firma Guardada!.",   
-//  						                			type: "success",   
-//  						                			showCancelButton: false,   
-//  						                			confirmButtonColor: "#3a5a74",   
-//  						                			confirmButtonText: "Aceptar",   
+//  						            	    		title: "",Â Â 
+//  						            	    		text: "Firma Guardada!.", Â Â 
+//  						                			type: "success", Â Â 
+//  						                			showCancelButton: false, Â Â 
+//  						                			confirmButtonColor: "#3a5a74", Â Â 
+//  						                			confirmButtonText: "Aceptar", Â Â 
 //  						                			closeOnConfirm: true }, 
 //  						                			function(){
 //  						                				cargaTareas();
@@ -1690,52 +1690,53 @@
  	        		text: "Aceptar", 
  	        		click:    function() {
  	        			var bandvalida = true;
- 	        			var parmarca = $("#marca").val();  
- 	        			if(parmarca==""){$("#sec-marca").addClass("has-error"); bandvalida=false;}else{$("#sec-marca").removeClass("has-error");}
+                                        var skipValidation = $("#formtecnico").is(':hidden') && $("#frmtipomantenimiento").val() === 'PREVENTIVO';
+                                        var parmarca = $("#marca").val();  
+ 	        			if(parmarca=="" && !skipValidation){$("#sec-marca").addClass("has-error"); bandvalida=false;}else{$("#sec-marca").removeClass("has-error");}
  	        			var parserie = $("#serie").val();  
- 	        			if(parserie==""){$("#sec-serie").addClass("has-error"); bandvalida=false;}else{$("#sec-serie").removeClass("has-error");}
+ 	        			if(parserie=="" && !skipValidation){$("#sec-serie").addClass("has-error"); bandvalida=false;}else{$("#sec-serie").removeClass("has-error");}
  	        			var parmodelo = $("#modelo").val();  
- 	        			if(parmodelo==""){$("#sec-modelo").addClass("has-error"); bandvalida=false;}else{$("#sec-modelo").removeClass("has-error");}
+ 	        			if(parmodelo=="" && !skipValidation){$("#sec-modelo").addClass("has-error"); bandvalida=false;}else{$("#sec-modelo").removeClass("has-error");}
  	        			var parvoltaje = $("#voltaje").val();  
- 	        			if(parvoltaje==""){$("#sec-parvoltaje").addClass("has-error"); bandvalida=false;}else{$("#sec-parvoltaje").removeClass("has-error");}
+ 	        			if(parvoltaje=="" && !skipValidation){$("#sec-parvoltaje").addClass("has-error"); bandvalida=false;}else{$("#sec-parvoltaje").removeClass("has-error");}
  	        			var paramperes = $("#amperes").val(); 
- 	        			if(paramperes==""){$("#sec-amperes").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes").removeClass("has-error");}
+ 	        			if(paramperes=="" && !skipValidation){$("#sec-amperes").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes").removeClass("has-error");}
 //  	        			var parrazonserv = $("#razonserv").val();  
  	        			var parservreal = $("#servreal option:selected").text();
- 	        			if(parservreal=="Seleccionar..."){$("#sec-servreal").addClass("has-error"); bandvalida=false;}else{$("#sec-servreal").removeClass("has-error");}
+ 	        			if(parservreal=="Seleccionar..." && !skipValidation){$("#sec-servreal").addClass("has-error"); bandvalida=false;}else{$("#sec-servreal").removeClass("has-error");}
  	        			var bandservreal = "";
  	        			if(parservreal=="OTRO")
  	        			{
  	        				bandservreal ="S";
  	        				parservreal=$("#otroServicioReal").val();  
- 	        				if(servreal==""){$("#sec-otroServicioReal").addClass("has-error"); bandvalida=false;}else{$("#sec-otroServicioReal").removeClass("has-error");}
+ 	        				if(servreal=="" && !skipValidation){$("#sec-otroServicioReal").addClass("has-error"); bandvalida=false;}else{$("#sec-otroServicioReal").removeClass("has-error");}
  	        			}
  	        			var parcomentarios = $("#comentarios").val();  
- 	        			if(parcomentarios==""){$("#sec-comentarios").addClass("has-error"); bandvalida=false;}else{$("#sec-comentarios").removeClass("has-error");}
+ 	        			if(parcomentarios=="" && !skipValidation){$("#sec-comentarios").addClass("has-error"); bandvalida=false;}else{$("#sec-comentarios").removeClass("has-error");}
  	        			var parcon1 = $("#cond1").val(); 
- 	        			if(parcon1==""){$("#sec-cond1").addClass("has-error"); bandvalida=false;}else{$("#sec-cond1").removeClass("has-error");}
+ 	        			if(parcon1=="" && !skipValidation){$("#sec-cond1").addClass("has-error"); bandvalida=false;}else{$("#sec-cond1").removeClass("has-error");}
 	 	   				var parcon2 = $("#cond2").val();  
-	 	   				if(parcon2==""){$("#sec-cond2").addClass("has-error"); bandvalida=false;}else{$("#sec-cond2").removeClass("has-error");}
+	 	   				if(parcon2=="" && !skipValidation){$("#sec-cond2").addClass("has-error"); bandvalida=false;}else{$("#sec-cond2").removeClass("has-error");}
 	 	   				var partempopera = $("#tempopera").val();  
-	 	   				if(partempopera==""){$("#sec-tempopera").addClass("has-error"); bandvalida=false;}else{$("#sec-tempopera").removeClass("has-error");}
+	 	   				if(partempopera=="" && !skipValidation){$("#sec-tempopera").addClass("has-error"); bandvalida=false;}else{$("#sec-tempopera").removeClass("has-error");}
 	 	   				var parvoltaje2 = $("#voltaje2").val(); 
-	 	   				if(parvoltaje2==""){$("#sec-voltaje2").addClass("has-error"); bandvalida=false;}else{$("#sec-voltaje2").removeClass("has-error");}
+	 	   				if(parvoltaje2=="" && !skipValidation){$("#sec-voltaje2").addClass("has-error"); bandvalida=false;}else{$("#sec-voltaje2").removeClass("has-error");}
 	 	   				var paramperes2 = $("#amperes2").val();
-	 	   				if(paramperes2==""){$("#sec-amperes2").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes2").removeClass("has-error");}
+	 	   				if(paramperes2=="" && !skipValidation){$("#sec-amperes2").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes2").removeClass("has-error");}
 	 	   				var partenicoserv = $("#tenicoserv").val();
 // 	 	   				if(partenicoserv==""){$("#sec-tenicoserv").addClass("has-error"); bandvalida=false;}else{$("#sec-tenicoserv").removeClass("has-error");}
 	 	   				var parnombreequipo =$("#nombreequipo option:selected").text();
-	 	   				if(parnombreequipo=="Seleccionar..."){$("#sec-nombreequipo").addClass("has-error"); bandvalida=false;}else{$("#sec-nombreequipo").removeClass("has-error");}
+	 	   				if(parnombreequipo=="Seleccionar..." && !skipValidation){$("#sec-nombreequipo").addClass("has-error"); bandvalida=false;}else{$("#sec-nombreequipo").removeClass("has-error");}
 	 	   				var bandEquipo ="";
 	 	   				if(parnombreequipo=="OTRO")
 	 	   				{
 	 	   				bandEquipo= "S";
 	 	   				parnombreequipo =$("#otroNombreEquipo").val();
-	 	   				if(parnombreequipo==""){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
+	 	   				if(parnombreequipo=="" && !skipValidation){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
 	 	   				}
 	 	   				var parservterminado = $('input[name=servterminado]:checked').val();
 	 	   				var partempounidad = $('input[name=tempounidad]:checked').val();
-	 	   				if(partempounidad==undefined){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
+	 	   				if(partempounidad==undefined && !skipValidation){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
 	 	   			    if(parservterminado==undefined){parservterminado=""}
  	        			var param = "accion=TERMINAR";
  	        			param += "&orden="+escape(idorden)+"&marca="+escape(parmarca)+"&serie="+escape(parserie)+"&modelo="+escape(parmodelo)+"&voltaje="+escape(parvoltaje)+"&amperes="+escape(paramperes)+"&servreal="+escape(parservreal)+"&comentarios="+escape(parcomentarios);
@@ -1762,12 +1763,12 @@
  											if(item.resp=="OK")
  											{
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Trabajo Terminado!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Trabajo Terminado!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1879,12 +1880,12 @@
  											if(item.resp=="OK")
  											{
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Trabajo Suspendido!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Trabajo Suspendido!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1942,13 +1943,13 @@
     function realizaREANUDAR(idorden,ordenserv, sigestatus,actualestatus,idaccion)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea reanudar el trabajo "+ordenserv+"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea reanudar el trabajo "+ordenserv+"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Cancelar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   				var param="accion=REANUDAR";
@@ -1974,12 +1975,12 @@
 										if(item.resp=="OK")
 										{
 											swal({
-					            	    		title: "",  
-					            	    		text: "Trabajo Reanudado!.",   
-					                			type: "success",   
-					                			showCancelButton: false,   
-					                			confirmButtonColor: "#3a5a74",   
-					                			confirmButtonText: "Aceptar",   
+					            	    		title: "",Â Â 
+					            	    		text: "Trabajo Reanudado!.", Â Â 
+					                			type: "success", Â Â 
+					                			showCancelButton: false, Â Â 
+					                			confirmButtonColor: "#3a5a74", Â Â 
+					                			confirmButtonText: "Aceptar", Â Â 
 					                			closeOnConfirm: true }, 
 					                			function(){
 					                				cargaTareas();
@@ -2008,13 +2009,13 @@
     function realizaCERRAR(idorden,ordenserv,sigestatus,actualestatus,idaccion)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea cerrar el trabajo "+ordenserv+"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea cerrar el trabajo "+ordenserv+"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Cancelar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   			
@@ -2041,12 +2042,12 @@
 										if(item.resp=="OK")
 										{
 											swal({
-					            	    		title: "",  
-					            	    		text: "Trabajo Cerrado!.",   
-					                			type: "success",   
-					                			showCancelButton: false,   
-					                			confirmButtonColor: "#3a5a74",   
-					                			confirmButtonText: "Aceptar",   
+					            	    		title: "",Â Â 
+					            	    		text: "Trabajo Cerrado!.", Â Â 
+					                			type: "success", Â Â 
+					                			showCancelButton: false, Â Â 
+					                			confirmButtonColor: "#3a5a74", Â Â 
+					                			confirmButtonText: "Aceptar", Â Â 
 					                			closeOnConfirm: true }, 
 					                			function(){
 					                				cargaTareas();
@@ -2076,13 +2077,13 @@
     function realizaELIMINAR(idorden,ordenserv,sigestatus,actualestatus,idaccion)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea eliminar el trabajo "+ordenserv+"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea eliminar el trabajo "+ordenserv+"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Eliminar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   			
@@ -2109,12 +2110,12 @@
 										if(item.resp=="OK")
 										{
 											swal({
-					            	    		title: "",  
-					            	    		text: "Trabajo Eliminado!.",   
-					                			type: "success",   
-					                			showCancelButton: false,   
-					                			confirmButtonColor: "#3a5a74",   
-					                			confirmButtonText: "Aceptar",   
+					            	    		title: "",Â Â 
+					            	    		text: "Trabajo Eliminado!.", Â Â 
+					                			type: "success", Â Â 
+					                			showCancelButton: false, Â Â 
+					                			confirmButtonColor: "#3a5a74", Â Â 
+					                			confirmButtonText: "Aceptar", Â Â 
 					                			closeOnConfirm: true }, 
 					                			function(){
 					                				cargaTareas();
@@ -2189,12 +2190,12 @@
  	   										if(item.resp=="OK")
  	   										{
  	   											swal({
- 	   					            	    		title: "",  
- 	   					            	    		text: "El trabajo ya puede ser terminado!.",   
- 	   					                			type: "success",   
- 	   					                			showCancelButton: false,   
- 	   					                			confirmButtonColor: "#3a5a74",   
- 	   					                			confirmButtonText: "Aceptar",   
+ 	   					            	    		title: "",Â Â 
+ 	   					            	    		text: "El trabajo ya puede ser terminado!.", Â Â 
+ 	   					                			type: "success", Â Â 
+ 	   					                			showCancelButton: false, Â Â 
+ 	   					                			confirmButtonColor: "#3a5a74", Â Â 
+ 	   					                			confirmButtonText: "Aceptar", Â Â 
  	   					                			closeOnConfirm: true }, 
  	   					                			function(){
  	   					                				modaldialog.dialog( "close" ); 
@@ -2220,7 +2221,7 @@
  	        			}
  	        			else
  	        			{
- 	        				swal("", "Debe seleccionar la confirmación para autorizar!", "error");
+ 	        				swal("", "Debe seleccionar la confirmaciÃ³n para autorizar!", "error");
  	        			}
  	        			
  	        			},
@@ -2366,12 +2367,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Costo Estimado Capturado!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Costo Estimado Capturado!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();

--- a/jsp/tareasLiquidadas.jsp
+++ b/jsp/tareasLiquidadas.jsp
@@ -171,7 +171,7 @@
 		<div class="col-xs-9">
 			<div class="row">
 			<div class="col-xs-12 col-sm-6">
-<!-- 				<input type="text" id="rango1" style="width:100%;" class="form-control" maxlength="4" placeholder="Mínimo"/> -->
+<!-- 				<input type="text" id="rango1" style="width:100%;" class="form-control" maxlength="4" placeholder="MÃ­nimo"/> -->
 				<div class='input-group date' id='fechainicio'>
                     <input type='text' class="form-control" />
                     <span class="input-group-addon">
@@ -180,7 +180,7 @@
                 </div>
 			</div>
 			<div class="col-xs-12 col-sm-6">
-<!-- 				<input type="text" id="rango2" style="width:100%;" class="form-control" maxlength="4" placeholder="Máximo"/> -->
+<!-- 				<input type="text" id="rango2" style="width:100%;" class="form-control" maxlength="4" placeholder="MÃ¡ximo"/> -->
 				<div class='input-group date' id='fechafin'>
                     <input type='text' class="form-control" />
                     <span class="input-group-addon">
@@ -287,18 +287,18 @@
 // 	            filteringType: "local",
 // 	            filteringCondition: "contains",
 // 	            highlightMatchesMode: "contains",
-// 	            placeHolder: "Buscar técnico...",
+// 	            placeHolder: "Buscar tÃ©cnico...",
 // 	            dropDownOrientation: "bottom"
 // // 	         	selectionChanged: storeTecnicos
 // 	        });
 // 		$("#selectTecnicoR").select2({
 // 			data:storeTecnicos,
-// 			placeholder: "Seleccione Técnico"
+// 			placeholder: "Seleccione TÃ©cnico"
 // 		});
 		
 // 		$("#selectTecnicoActual").select2({
 // 			data:storeTecnicoActual,
-// 			placeholder: "Seleccione Técnico"
+// 			placeholder: "Seleccione TÃ©cnico"
 // 		});
 
 		$('#fechainicio').datetimepicker(
@@ -476,7 +476,7 @@
     /**********************************************************************/ 
     function abrirASIGNAR(foliopisa,telefono,folioplex,expediente)
     {
-    	// En el parametro estado se le envia el estado en el que fue levantada la acción
+    	// En el parametro estado se le envia el estado en el que fue levantada la acciÃ³n
     	var parametros="";
     	if(tipoAccion == ""){
     		tipoAccion="Asignar";
@@ -506,7 +506,7 @@
     		  					if(resp.trim() == "COMPLETE"){
     		  						resp="LIQUIDADA";
     		  					}
-    		  					swal("", "No se pudo realizo la acción porque la tarea ya esta " + resp+".", "error");
+    		  					swal("", "No se pudo realizo la acciÃ³n porque la tarea ya esta " + resp+".", "error");
     		  					cargaTareas();
     		  				}
     		  				tipoAccion="";
@@ -527,7 +527,7 @@
             height: 400,
             width: 500,
             modal: true,
-            title: "Reasignación de Tarea",
+            title: "ReasignaciÃ³n de Tarea",
             buttons: [{
               text : "Aceptar",
               "class": "btn btn-primary",
@@ -539,13 +539,13 @@
   	  			if(expedienteNuevo!="" && expedienteNuevo!=undefined)
   	  			{
   	    	swal({
-  	    		title: "",  
-  	    		text: "¿Desea asignar la orden "+foliopisa+" al tecnico "+nombre+"?",     
-      			type: "info",   
-      			showCancelButton: true,   
+  	    		title: "",Â Â 
+  	    		text: "Â¿Desea asignar la orden "+foliopisa+" al tecnico "+nombre+"?", Â Â Â Â 
+      			type: "info", Â Â 
+      			showCancelButton: true, Â Â 
       			cancelButtonText: "Cancelar",
-      			confirmButtonColor: "#3a5a74",   
-      			confirmButtonText: "Aceptar",   
+      			confirmButtonColor: "#3a5a74", Â Â 
+      			confirmButtonText: "Aceptar", Â Â 
       			closeOnConfirm: false }, 
       			function(){
        				$.ajax({
@@ -557,12 +557,12 @@
                  				{
 			                 				
 			                 				swal({
-				            	    		title: "",  
-				            	    		text: "La asignación de tarea(s) fue satisfactoria.",   
-				                			type: "success",   
-				                			showCancelButton: false,   
-				                			confirmButtonColor: "#3a5a74",   
-				                			confirmButtonText: "Aceptar",   
+				            	    		title: "",Â Â 
+				            	    		text: "La asignaciÃ³n de tarea(s) fue satisfactoria.", Â Â 
+				                			type: "success", Â Â 
+				                			showCancelButton: false, Â Â 
+				                			confirmButtonColor: "#3a5a74", Â Â 
+				                			confirmButtonText: "Aceptar", Â Â 
 				                			closeOnConfirm: true }, 
 				                			function(){
 				                				//Borrar tarea del panel de Tareas
@@ -585,7 +585,7 @@
   	  }
   	  else
   		  {
-  		  swal("Debe seleccionar un técnico", "", "warning");
+  		  swal("Debe seleccionar un tÃ©cnico", "", "warning");
   		  }
 //             	  var expediente=$("#selectTecnico").find("option:selected").val();
 //             	  var nombre=$("#selectTecnicoR").find("option:selected").text();
@@ -594,13 +594,13 @@
 //             	  if(expediente!="")
 //             	  {
 //             	    	swal({
-//             	    		title: "",  
-//             	    		text: "Desea asignar la order "+folioplex+" al tecnico "+nombre+"?",    
-//                 			type: "info",   
-//                 			showCancelButton: true,   
+//             	    		title: "",Â Â 
+//             	    		text: "Desea asignar la order "+folioplex+" al tecnico "+nombre+"?", Â Â Â 
+//                 			type: "info", Â Â 
+//                 			showCancelButton: true, Â Â 
 //                 			cancelButtonText: "Cancelar",
-//                 			confirmButtonColor: "#3a5a74",   
-//                 			confirmButtonText: "Aceptar",   
+//                 			confirmButtonColor: "#3a5a74", Â Â 
+//                 			confirmButtonText: "Aceptar", Â Â 
 //                 			closeOnConfirm: true }, 
 //                 			function(){
 //                         				$.ajax({
@@ -659,7 +659,7 @@
 //             	  }
 //             	  else
 //             		  {
-//             		  swal("Debe seleccionar un técnico", "", "warning");
+//             		  swal("Debe seleccionar un tÃ©cnico", "", "warning");
 //             		  }
             	  
             	  }
@@ -686,16 +686,16 @@
 							if(resp.trim()=="OK")
     		  				{
     		  					swal({
-					    		title: "",  
-					    		text: "¿Desea despachar la orden: "+foliopisa+"?",      
-					    			type: "info",   
-					    			showCancelButton: true,   
+					    		title: "",Â Â 
+					    		text: "Â¿Desea despachar la orden: "+foliopisa+"?", Â Â  Â Â 
+					    			type: "info", Â Â 
+					    			showCancelButton: true, Â Â 
 					    			cancelButtonText: "Cancelar",
-					    			confirmButtonColor: "#3a5a74",    
-					    			confirmButtonText: "Aceptar",   
+					    			confirmButtonColor: "#3a5a74", Â Â Â 
+					    			confirmButtonText: "Aceptar", Â Â 
 					    			closeOnConfirm: true }, 
 					    			function(){
-					    				  var parametros="estado=DESPACHADA&tipo=DESPACHADA&folioplex="+folioplex+"&foliopisa="+foliopisa;
+					    				Â Â var parametros="estado=DESPACHADA&tipo=DESPACHADA&folioplex="+folioplex+"&foliopisa="+foliopisa;
 					    		    	$.ajax({
 					    		  			url: 'actualizaEstado.jsp?'+parametros,
 					    		  			type: "GET",
@@ -809,7 +809,7 @@
         autoOpen: false,
         height: 400,
         width: 350,
-        title: "Liquidación",
+        title: "LiquidaciÃ³n",
         modal: true
         });
     
@@ -870,7 +870,7 @@
     /***********************************/  
     function abrirOBJETAR(foliopisa,telefono,folioplex,expediente,estado)
     {
-		// En el parametro estado se le envia el estado en el que fue levantada la acción
+		// En el parametro estado se le envia el estado en el que fue levantada la acciÃ³n
     	var parametros = "folioplex="+folioplex+"&estado=DESPACHADA";
   		$.ajax({
 		url: "../ValidarEstadoTarea?"+parametros,
@@ -887,7 +887,7 @@
 	  					if(resp.trim() == "COMPLETE"){
 	  						resp="LIQUIDADA";
 	  					}
-	  					swal("", "No se pudo realizo la acción porque la tarea ya esta " + resp+".", "error");
+	  					swal("", "No se pudo realizo la acciÃ³n porque la tarea ya esta " + resp+".", "error");
 	  					cargaTareas();
 		  			}
 				}
@@ -906,13 +906,13 @@
   		  	{
     	
 		    	swal({
-		    		title: "",  
-		    		text: "¿Desea liquidar la orden: "+foliopisa+"?",   
-	    			type: "info",   
-	    			showCancelButton: true,   
+		    		title: "",Â Â 
+		    		text: "Â¿Desea liquidar la orden: "+foliopisa+"?", Â Â 
+	    			type: "info", Â Â 
+	    			showCancelButton: true, Â Â 
 	    			cancelButtonText: "Cancelar",
-	    			confirmButtonColor: "#3a5a74",    
-	    			confirmButtonText: "Liquidar",   
+	    			confirmButtonColor: "#3a5a74", Â Â Â 
+	    			confirmButtonText: "Liquidar", Â Â 
 	    			closeOnConfirm: true }, 
 	    			function(){
 	    				var parametros="estado=COMPLETE&tipo=COMPLETE&folioplex="+folioplex+"&foliopisa="+foliopisa;
@@ -1116,12 +1116,12 @@
  											if(item.resp=="OK")
  											{
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Incidencia Capturada!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Incidencia Capturada!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1183,7 +1183,7 @@
     	var tituloform = "";
     	var alto = 0;
 
-    		tituloform = "Reasignar Técnico";
+    		tituloform = "Reasignar TÃ©cnico";
     		alto = 500;
 
     	var modaldialog = $("#dialog").dialog({
@@ -1226,12 +1226,12 @@
  											if(item.resp=="OK")
  											{
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Incidencia Asignada!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Incidencia Asignada!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1285,7 +1285,7 @@
     	var tituloform = "";
     	var alto = 0;
 
-    		tituloform = "Asignar Técnico";
+    		tituloform = "Asignar TÃ©cnico";
     		alto = 500;
 
     	var modaldialog = $("#dialog").dialog({
@@ -1326,12 +1326,12 @@
  											if(item.resp=="OK")
  											{
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Incidencia Asignada!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Incidencia Asignada!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1428,12 +1428,12 @@
  											if(item.resp=="OK")
  											{
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Trabajo en Curso!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Trabajo en Curso!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1583,12 +1583,12 @@
 //  											if(item.resp=="OK")
 //  											{
 //  												swal({
-//  						            	    		title: "",  
-//  						            	    		text: "Firma Guardada!.",   
-//  						                			type: "success",   
-//  						                			showCancelButton: false,   
-//  						                			confirmButtonColor: "#3a5a74",   
-//  						                			confirmButtonText: "Aceptar",   
+//  						            	    		title: "",Â Â 
+//  						            	    		text: "Firma Guardada!.", Â Â 
+//  						                			type: "success", Â Â 
+//  						                			showCancelButton: false, Â Â 
+//  						                			confirmButtonColor: "#3a5a74", Â Â 
+//  						                			confirmButtonText: "Aceptar", Â Â 
 //  						                			closeOnConfirm: true }, 
 //  						                			function(){
 //  						                				cargaTareas();
@@ -1688,52 +1688,53 @@
  	        		text: "Aceptar", 
  	        		click:    function() {
  	        			var bandvalida = true;
- 	        			var parmarca = $("#marca").val();  
- 	        			if(parmarca==""){$("#sec-marca").addClass("has-error"); bandvalida=false;}else{$("#sec-marca").removeClass("has-error");}
+                                        var skipValidation = $("#formtecnico").is(':hidden') && $("#frmtipomantenimiento").val() === 'PREVENTIVO';
+                                        var parmarca = $("#marca").val();  
+ 	        			if(parmarca=="" && !skipValidation){$("#sec-marca").addClass("has-error"); bandvalida=false;}else{$("#sec-marca").removeClass("has-error");}
  	        			var parserie = $("#serie").val();  
- 	        			if(parserie==""){$("#sec-serie").addClass("has-error"); bandvalida=false;}else{$("#sec-serie").removeClass("has-error");}
+ 	        			if(parserie=="" && !skipValidation){$("#sec-serie").addClass("has-error"); bandvalida=false;}else{$("#sec-serie").removeClass("has-error");}
  	        			var parmodelo = $("#modelo").val();  
- 	        			if(parmodelo==""){$("#sec-modelo").addClass("has-error"); bandvalida=false;}else{$("#sec-modelo").removeClass("has-error");}
+ 	        			if(parmodelo=="" && !skipValidation){$("#sec-modelo").addClass("has-error"); bandvalida=false;}else{$("#sec-modelo").removeClass("has-error");}
  	        			var parvoltaje = $("#voltaje").val();  
- 	        			if(parvoltaje==""){$("#sec-parvoltaje").addClass("has-error"); bandvalida=false;}else{$("#sec-parvoltaje").removeClass("has-error");}
+ 	        			if(parvoltaje=="" && !skipValidation){$("#sec-parvoltaje").addClass("has-error"); bandvalida=false;}else{$("#sec-parvoltaje").removeClass("has-error");}
  	        			var paramperes = $("#amperes").val(); 
- 	        			if(paramperes==""){$("#sec-amperes").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes").removeClass("has-error");}
+ 	        			if(paramperes=="" && !skipValidation){$("#sec-amperes").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes").removeClass("has-error");}
 //  	        			var parrazonserv = $("#razonserv").val();  
  	        			var parservreal = $("#servreal option:selected").text();
- 	        			if(parservreal=="Seleccionar..."){$("#sec-servreal").addClass("has-error"); bandvalida=false;}else{$("#sec-servreal").removeClass("has-error");}
+ 	        			if(parservreal=="Seleccionar..." && !skipValidation){$("#sec-servreal").addClass("has-error"); bandvalida=false;}else{$("#sec-servreal").removeClass("has-error");}
  	        			var bandservreal = "";
  	        			if(parservreal=="OTRO")
  	        			{
  	        				bandservreal ="S";
  	        				parservreal=$("#otroServicioReal").val();  
- 	        				if(servreal==""){$("#sec-otroServicioReal").addClass("has-error"); bandvalida=false;}else{$("#sec-otroServicioReal").removeClass("has-error");}
+ 	        				if(servreal=="" && !skipValidation){$("#sec-otroServicioReal").addClass("has-error"); bandvalida=false;}else{$("#sec-otroServicioReal").removeClass("has-error");}
  	        			}
  	        			var parcomentarios = $("#comentarios").val();  
- 	        			if(parcomentarios==""){$("#sec-comentarios").addClass("has-error"); bandvalida=false;}else{$("#sec-comentarios").removeClass("has-error");}
+ 	        			if(parcomentarios=="" && !skipValidation){$("#sec-comentarios").addClass("has-error"); bandvalida=false;}else{$("#sec-comentarios").removeClass("has-error");}
  	        			var parcon1 = $("#cond1").val(); 
- 	        			if(parcon1==""){$("#sec-cond1").addClass("has-error"); bandvalida=false;}else{$("#sec-cond1").removeClass("has-error");}
+ 	        			if(parcon1=="" && !skipValidation){$("#sec-cond1").addClass("has-error"); bandvalida=false;}else{$("#sec-cond1").removeClass("has-error");}
 	 	   				var parcon2 = $("#cond2").val();  
-	 	   				if(parcon2==""){$("#sec-cond2").addClass("has-error"); bandvalida=false;}else{$("#sec-cond2").removeClass("has-error");}
+	 	   				if(parcon2=="" && !skipValidation){$("#sec-cond2").addClass("has-error"); bandvalida=false;}else{$("#sec-cond2").removeClass("has-error");}
 	 	   				var partempopera = $("#tempopera").val();  
-	 	   				if(partempopera==""){$("#sec-tempopera").addClass("has-error"); bandvalida=false;}else{$("#sec-tempopera").removeClass("has-error");}
+	 	   				if(partempopera=="" && !skipValidation){$("#sec-tempopera").addClass("has-error"); bandvalida=false;}else{$("#sec-tempopera").removeClass("has-error");}
 	 	   				var parvoltaje2 = $("#voltaje2").val(); 
-	 	   				if(parvoltaje2==""){$("#sec-voltaje2").addClass("has-error"); bandvalida=false;}else{$("#sec-voltaje2").removeClass("has-error");}
+	 	   				if(parvoltaje2=="" && !skipValidation){$("#sec-voltaje2").addClass("has-error"); bandvalida=false;}else{$("#sec-voltaje2").removeClass("has-error");}
 	 	   				var paramperes2 = $("#amperes2").val();
-	 	   				if(paramperes2==""){$("#sec-amperes2").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes2").removeClass("has-error");}
+	 	   				if(paramperes2=="" && !skipValidation){$("#sec-amperes2").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes2").removeClass("has-error");}
 	 	   				var partenicoserv = $("#tenicoserv").val();
 // 	 	   				if(partenicoserv==""){$("#sec-tenicoserv").addClass("has-error"); bandvalida=false;}else{$("#sec-tenicoserv").removeClass("has-error");}
 	 	   				var parnombreequipo =$("#nombreequipo option:selected").text();
-	 	   				if(parnombreequipo=="Seleccionar..."){$("#sec-nombreequipo").addClass("has-error"); bandvalida=false;}else{$("#sec-nombreequipo").removeClass("has-error");}
+	 	   				if(parnombreequipo=="Seleccionar..." && !skipValidation){$("#sec-nombreequipo").addClass("has-error"); bandvalida=false;}else{$("#sec-nombreequipo").removeClass("has-error");}
 	 	   				var bandEquipo ="";
 	 	   				if(parnombreequipo=="OTRO")
 	 	   				{
 	 	   				bandEquipo= "S";
 	 	   				parnombreequipo =$("#otroNombreEquipo").val();
-	 	   				if(parnombreequipo==""){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
+	 	   				if(parnombreequipo=="" && !skipValidation){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
 	 	   				}
 	 	   				var parservterminado = $('input[name=servterminado]:checked').val();
 	 	   				var partempounidad = $('input[name=tempounidad]:checked').val();
-	 	   				if(partempounidad==undefined){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
+	 	   				if(partempounidad==undefined && !skipValidation){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
 	 	   			    if(parservterminado==undefined){parservterminado=""}
  	        			var param = "accion=TERMINAR";
  	        			param += "&orden="+escape(idorden)+"&marca="+escape(parmarca)+"&serie="+escape(parserie)+"&modelo="+escape(parmodelo)+"&voltaje="+escape(parvoltaje)+"&amperes="+escape(paramperes)+"&servreal="+escape(parservreal)+"&comentarios="+escape(parcomentarios);
@@ -1760,12 +1761,12 @@
  											if(item.resp=="OK")
  											{
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Trabajo Terminado!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Trabajo Terminado!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1877,12 +1878,12 @@
  											if(item.resp=="OK")
  											{
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Trabajo Suspendido!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Trabajo Suspendido!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1940,13 +1941,13 @@
     function realizaREANUDAR(idorden,ordenserv, sigestatus,actualestatus,idaccion)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea reanudar el trabajo "+ordenserv+"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea reanudar el trabajo "+ordenserv+"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Cancelar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   				var param="accion=REANUDAR";
@@ -1972,12 +1973,12 @@
 										if(item.resp=="OK")
 										{
 											swal({
-					            	    		title: "",  
-					            	    		text: "Trabajo Reanudado!.",   
-					                			type: "success",   
-					                			showCancelButton: false,   
-					                			confirmButtonColor: "#3a5a74",   
-					                			confirmButtonText: "Aceptar",   
+					            	    		title: "",Â Â 
+					            	    		text: "Trabajo Reanudado!.", Â Â 
+					                			type: "success", Â Â 
+					                			showCancelButton: false, Â Â 
+					                			confirmButtonColor: "#3a5a74", Â Â 
+					                			confirmButtonText: "Aceptar", Â Â 
 					                			closeOnConfirm: true }, 
 					                			function(){
 					                				cargaTareas();
@@ -2006,13 +2007,13 @@
     function realizaCERRAR(idorden,ordenserv,sigestatus,actualestatus,idaccion)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea cerrar el trabajo "+ordenserv+"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea cerrar el trabajo "+ordenserv+"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Cancelar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   			
@@ -2039,12 +2040,12 @@
 										if(item.resp=="OK")
 										{
 											swal({
-					            	    		title: "",  
-					            	    		text: "Trabajo Cerrado!.",   
-					                			type: "success",   
-					                			showCancelButton: false,   
-					                			confirmButtonColor: "#3a5a74",   
-					                			confirmButtonText: "Aceptar",   
+					            	    		title: "",Â Â 
+					            	    		text: "Trabajo Cerrado!.", Â Â 
+					                			type: "success", Â Â 
+					                			showCancelButton: false, Â Â 
+					                			confirmButtonColor: "#3a5a74", Â Â 
+					                			confirmButtonText: "Aceptar", Â Â 
 					                			closeOnConfirm: true }, 
 					                			function(){
 					                				cargaTareas();
@@ -2074,13 +2075,13 @@
     function realizaELIMINAR(idorden,ordenserv,sigestatus,actualestatus,idaccion)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea eliminar el trabajo "+ordenserv+"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea eliminar el trabajo "+ordenserv+"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Eliminar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   			
@@ -2107,12 +2108,12 @@
 										if(item.resp=="OK")
 										{
 											swal({
-					            	    		title: "",  
-					            	    		text: "Trabajo Eliminado!.",   
-					                			type: "success",   
-					                			showCancelButton: false,   
-					                			confirmButtonColor: "#3a5a74",   
-					                			confirmButtonText: "Aceptar",   
+					            	    		title: "",Â Â 
+					            	    		text: "Trabajo Eliminado!.", Â Â 
+					                			type: "success", Â Â 
+					                			showCancelButton: false, Â Â 
+					                			confirmButtonColor: "#3a5a74", Â Â 
+					                			confirmButtonText: "Aceptar", Â Â 
 					                			closeOnConfirm: true }, 
 					                			function(){
 					                				cargaTareas();
@@ -2187,12 +2188,12 @@
  	   										if(item.resp=="OK")
  	   										{
  	   											swal({
- 	   					            	    		title: "",  
- 	   					            	    		text: "El trabajo ya puede ser terminado!.",   
- 	   					                			type: "success",   
- 	   					                			showCancelButton: false,   
- 	   					                			confirmButtonColor: "#3a5a74",   
- 	   					                			confirmButtonText: "Aceptar",   
+ 	   					            	    		title: "",Â Â 
+ 	   					            	    		text: "El trabajo ya puede ser terminado!.", Â Â 
+ 	   					                			type: "success", Â Â 
+ 	   					                			showCancelButton: false, Â Â 
+ 	   					                			confirmButtonColor: "#3a5a74", Â Â 
+ 	   					                			confirmButtonText: "Aceptar", Â Â 
  	   					                			closeOnConfirm: true }, 
  	   					                			function(){
  	   					                				modaldialog.dialog( "close" ); 
@@ -2218,7 +2219,7 @@
  	        			}
  	        			else
  	        			{
- 	        				swal("", "Debe seleccionar la confirmación para autorizar!", "error");
+ 	        				swal("", "Debe seleccionar la confirmaciÃ³n para autorizar!", "error");
  	        			}
  	        			
  	        			},
@@ -2364,12 +2365,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Costo Estimado Capturado!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Costo Estimado Capturado!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();


### PR DESCRIPTION
## Summary
- Skip required-field validation when the technician form is hidden and the maintenance type is PREVENTIVO.
- Apply the check across standard, client, and settled task flows.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bec7a5ffc83329005f4d90a8f9b5d