### PR TITLE
Allow PREVENTIVO submissions when technician form hidden

### DIFF
--- a/jsp/formTerminar.jsp
+++ b/jsp/formTerminar.jsp
@@ -315,7 +315,10 @@
                                 var cliente = encodeURIComponent($('#frmcliente').val());
                                 $('#tabAire').attr('src', '../maintenance-form?orden=' + orden + '&cliente=' + cliente);
                                 $('#tabRefrigeracion').attr('src', '../refrigeracion-form?orden=' + orden + '&cliente=' + cliente);
-                                $('#aceptarform').on('mousedown', function(){
+                        }
+
+                        $('#aceptarform').on('mousedown', function(){
+                                if($('#formtecnico').is(':hidden') && $('#frmtipomantenimiento').val() === 'PREVENTIVO'){
                                         $('#marca, #serie, #modelo, #comentarios, #tenicoserv').val('NA');
                                         $('#cond1, #cond2').val('0');
                                         $('#voltaje, #amperes, #tempopera, #voltaje2, #amperes2').val('0');
@@ -323,8 +326,8 @@
                                         $('#nombreequipo').prop('selectedIndex',1);
                                         $('input[name=servterminado]').first().prop('checked',true);
                                         $('input[name=tempounidad]').first().prop('checked',true);
-                                });
-                        }
+                                }
+                        });
 
                         $('#tabAireLink').on('click', function(e){
                                 e.preventDefault();

--- a/jsp/formTerminarMovil.jsp
+++ b/jsp/formTerminarMovil.jsp
@@ -548,8 +548,9 @@
                                 $("#frmultimotec").attr('disabled','disabled');
                         }
 
-                        if($('#formtecnico').is(':hidden') && $('#frmtipomantenimiento').val() === 'PREVENTIVO'){
-                                $('#aceptarform').on('mousedown', function(){
+
+                        $('#aceptarform').on('mousedown', function(){
+                                if($('#formtecnico').is(':hidden') && $('#frmtipomantenimiento').val() === 'PREVENTIVO'){
                                         $('#marca, #serie, #modelo, #comentarios, #tenicoserv').val('NA');
                                         $('#cond1, #cond2').val('0');
                                         $('#voltaje, #amperes, #tempopera, #voltaje2, #amperes2').val('0');
@@ -557,8 +558,8 @@
                                         $('#nombreequipo').prop('selectedIndex',1);
                                         $('input[name=servterminado]').first().prop('checked',true);
                                         $('input[name=tempounidad]').first().prop('checked',true);
-                                });
-                        }
+                                }
+                        });
 
 
                  consultaFacturas("C");


### PR DESCRIPTION
## Summary
- permit `aceptarform` submission when technician details are hidden and maintenance type is PREVENTIVO

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bef8ae7bc83329481554773a0f6e0