### PR TITLE
Add submission bypass for aceptarform

### DIFF
--- a/jsp/formTerminar.jsp
+++ b/jsp/formTerminar.jsp
@@ -317,8 +317,8 @@
                                 $('#tabRefrigeracion').attr('src', '../refrigeracion-form?orden=' + orden + '&cliente=' + cliente);
                         }
 
-                        $('#aceptarform').on('mousedown', function(){
-                                if($('#formtecnico').is(':hidden') && $('#frmtipomantenimiento').val() === 'PREVENTIVO'){
+                       $('#aceptarform').on('mousedown touchstart', function(){
+                               if($('#formtecnico').is(':hidden') && $('#frmtipomantenimiento').val() === 'PREVENTIVO'){
                                         $('#marca, #serie, #modelo, #comentarios, #tenicoserv').val('NA');
                                         $('#cond1, #cond2').val('0');
                                         $('#voltaje, #amperes, #tempopera, #voltaje2, #amperes2').val('0');

--- a/jsp/formTerminarMovil.jsp
+++ b/jsp/formTerminarMovil.jsp
@@ -549,8 +549,8 @@
                         }
 
 
-                        $('#aceptarform').on('mousedown', function(){
-                                if($('#formtecnico').is(':hidden') && $('#frmtipomantenimiento').val() === 'PREVENTIVO'){
+                       $('#aceptarform').on('mousedown touchstart', function(){
+                               if($('#formtecnico').is(':hidden') && $('#frmtipomantenimiento').val() === 'PREVENTIVO'){
                                         $('#marca, #serie, #modelo, #comentarios, #tenicoserv').val('NA');
                                         $('#cond1, #cond2').val('0');
                                         $('#voltaje, #amperes, #tempopera, #voltaje2, #amperes2').val('0');


### PR DESCRIPTION
## Summary
- Ensure aceptarform handler runs on mousedown and touchstart to prefill preventive maintenance data

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bf217696c8332b1e5d2bf4e24f5c2