### PR TITLE
Allow preventive submissions without technical details

### DIFF
--- a/jsp/tareas.jsp
+++ b/jsp/tareas.jsp
@@ -1111,9 +1111,10 @@
  	        			{
  	        				razonserv =razonserv;
  	        			}
- 	        			var prioridad =$("#prioridad").val();
- 	        			if(prioridad==""){$("#sec-prioridad").addClass("has-error"); bandvalida=false;}else{$("#sec-prioridad").removeClass("has-error");}
- 	        			var param = "accion=A";
+                                        var prioridad =$("#prioridad").val();
+                                        if(prioridad==""){$("#sec-prioridad").addClass("has-error"); bandvalida=false;}else{$("#sec-prioridad").removeClass("has-error");}
+                                        if($("#formtecnico").is(':hidden') && $("#frmtipomantenimiento").val()=="PREVENTIVO"){bandvalida=true;}
+                                        var param = "accion=A";
  	        			param += "&orden="+escape(forden)+"&tipomantenimiento="+escape(ftipomant)+"&empresa="+escape(fcliente)+"&ciudad="+escape(fciudad)+"&sucursal="+escape(fsucursal)+"&direccion="+escape(fdireccion)+"&gerente="+escape(fgerentesup)+"&fechareg="+escape(fechareg)+"&horareg="+escape(horareg)+"&usuario=<%=usuario%>&razonserv="+escape(razonserv)+"&prioridad="+escape(prioridad)+"&bandRazonserv="+bandRazonserv+"&zona="+fzona+"&subzona="+detallezona;
  	        			if(bandvalida)
  	        			{

--- a/jsp/tareasCliente.jsp
+++ b/jsp/tareasCliente.jsp
@@ -1093,9 +1093,10 @@
  	        			{
  	        				razonserv =razonserv;
  	        			}
- 	        			var prioridad =$("#prioridad").val();
- 	        			if(prioridad==""){$("#sec-prioridad").addClass("has-error"); bandvalida=false;}else{$("#sec-prioridad").removeClass("has-error");}
- 	        			var param = "accion=A";
+                                        var prioridad =$("#prioridad").val();
+                                        if(prioridad==""){$("#sec-prioridad").addClass("has-error"); bandvalida=false;}else{$("#sec-prioridad").removeClass("has-error");}
+                                        if($("#formtecnico").is(':hidden') && $("#frmtipomantenimiento").val()=="PREVENTIVO"){bandvalida=true;}
+                                        var param = "accion=A";
  	        			param += "&orden="+escape(forden)+"&tipomantenimiento="+escape(ftipomant)+"&empresa="+escape(fcliente)+"&ciudad="+escape(fciudad)+"&sucursal="+escape(fsucursal)+"&direccion="+escape(fdireccion)+"&gerente="+escape(fgerentesup)+"&fechareg="+escape(fechareg)+"&horareg="+escape(horareg)+"&usuario=<%=usuario%>&razonserv="+escape(razonserv)+"&prioridad="+escape(prioridad)+"&bandRazonserv="+bandRazonserv;
  	        			if(bandvalida)
  	        			{

--- a/jsp/tareasLiquidadas.jsp
+++ b/jsp/tareasLiquidadas.jsp
@@ -1091,9 +1091,10 @@
  	        			{
  	        				razonserv =razonserv;
  	        			}
- 	        			var prioridad =$("#prioridad").val();
- 	        			if(prioridad==""){$("#sec-prioridad").addClass("has-error"); bandvalida=false;}else{$("#sec-prioridad").removeClass("has-error");}
- 	        			var param = "accion=A";
+                                        var prioridad =$("#prioridad").val();
+                                        if(prioridad==""){$("#sec-prioridad").addClass("has-error"); bandvalida=false;}else{$("#sec-prioridad").removeClass("has-error");}
+                                        if($("#formtecnico").is(':hidden') && $("#frmtipomantenimiento").val()=="PREVENTIVO"){bandvalida=true;}
+                                        var param = "accion=A";
  	        			param += "&orden="+escape(forden)+"&tipomantenimiento="+escape(ftipomant)+"&empresa="+escape(fcliente)+"&ciudad="+escape(fciudad)+"&sucursal="+escape(fsucursal)+"&direccion="+escape(fdireccion)+"&gerente="+escape(fgerentesup)+"&fechareg="+escape(fechareg)+"&horareg="+escape(horareg)+"&usuario=<%=usuario%>&razonserv="+escape(razonserv)+"&prioridad="+escape(prioridad)+"&bandRazonserv="+bandRazonserv;
  	        			if(bandvalida)
  	        			{


### PR DESCRIPTION
## Summary
- Allow preventive maintenance tasks to bypass technical detail validation when the technical form is hidden

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bfe5c1b108332a52b60d7d0689584