### PR TITLE
Allow preventive submissions without technical details

### DIFF
--- a/assets/js/resumenTareas.js
+++ b/assets/js/resumenTareas.js
@@ -92,4 +92,12 @@
       }
     };
   }
+
+  if (typeof global.cargaTareas !== 'function') {
+    global.cargaTareas = function() {
+      if (global.location && typeof global.location.reload === 'function') {
+        global.location.reload();
+      }
+    };
+  }
 })(this);

--- a/jsp/resumenTareas.jsp
+++ b/jsp/resumenTareas.jsp
@@ -149,17 +149,19 @@
                                     	<a href="#" onclick="ultimaPag();"><img border="0" src="<%=request.getContextPath()%>/assets/img/page-last.gif" alt="Ultima" width="16" height="16"></a>
                                     	</span>  
                              
-                                    </td>
-  <script src="../assets/js/resumenTareas.js"></script>
-  var usuarioAccion = '<%=usuario%>';
+                                   </td>
                                     <td align="right" width="50%"> <span>Página <%=pagina %> de <%=TOTALPAGINASAg %> </span></td>
-                                </tr>                                
+                                </tr>
                         </table>
-				
-					
-				</div>
-    
- 
+
+
+                                </div>
+
+  <script>
+    var usuarioAccion = '<%=usuario%>';
+  </script>
+  <script src="../assets/js/resumenTareas.js"></script>
+
   <script>
     
 //   checkedRows = [];
@@ -265,7 +267,7 @@
 	}
 
     $('#tablaTareas').on('click', '.clickable-row', function(event) {
-  	  $(this).addClass('active').siblings().removeClass('active');
-  	});
+          $(this).addClass('active').siblings().removeClass('active');
+        });
 
- </script>   
+ </script>

--- a/jsp/resumenTareasCliente.jsp
+++ b/jsp/resumenTareasCliente.jsp
@@ -151,8 +151,12 @@
                                     	</span>  
                              
                                     </td>
-                                    <td align="right" width="50%"> <span>Página <%=pagina %> de <%=TOTALPAGINASAg %> </span></td>
-                                </tr>                                
+
+  <script>
+    var usuarioAccion = '<%=usuario%>';
+  </script>
+  <script src="../assets/js/resumenTareas.js"></script>
+
                         </table>
 				
 					
@@ -267,4 +271,4 @@
   	  $(this).addClass('active').siblings().removeClass('active');
   	});
 
- </script>   
+ </script>

--- a/jsp/resumenTareasLiquidadas.jsp
+++ b/jsp/resumenTareasLiquidadas.jsp
@@ -166,8 +166,12 @@
 				
 					
 				</div>
-    
- 
+
+  <script>
+    var usuarioAccion = '<%=usuario%>';
+  </script>
+  <script src="../assets/js/resumenTareas.js"></script>
+
   <script>
     
 //   checkedRows = [];
@@ -287,4 +291,4 @@ function realizaIMPRESION(idorden, ordenserv, tipo) {
   	  $(this).addClass('active').siblings().removeClass('active');
   	});
 
- </script>   
+ </script>

--- a/jsp/tareas.jsp
+++ b/jsp/tareas.jsp
@@ -1111,9 +1111,10 @@
  	        			{
  	        				razonserv =razonserv;
  	        			}
- 	        			var prioridad =$("#prioridad").val();
- 	        			if(prioridad==""){$("#sec-prioridad").addClass("has-error"); bandvalida=false;}else{$("#sec-prioridad").removeClass("has-error");}
- 	        			var param = "accion=A";
+                                        var prioridad =$("#prioridad").val();
+                                        if(prioridad==""){$("#sec-prioridad").addClass("has-error"); bandvalida=false;}else{$("#sec-prioridad").removeClass("has-error");}
+                                        if($("#formtecnico").is(':hidden') && $("#frmtipomantenimiento").val()=="PREVENTIVO"){bandvalida=true;}
+                                        var param = "accion=A";
  	        			param += "&orden="+escape(forden)+"&tipomantenimiento="+escape(ftipomant)+"&empresa="+escape(fcliente)+"&ciudad="+escape(fciudad)+"&sucursal="+escape(fsucursal)+"&direccion="+escape(fdireccion)+"&gerente="+escape(fgerentesup)+"&fechareg="+escape(fechareg)+"&horareg="+escape(horareg)+"&usuario=<%=usuario%>&razonserv="+escape(razonserv)+"&prioridad="+escape(prioridad)+"&bandRazonserv="+bandRazonserv+"&zona="+fzona+"&subzona="+detallezona;
  	        			if(bandvalida)
  	        			{

--- a/jsp/tareasCliente.jsp
+++ b/jsp/tareasCliente.jsp
@@ -1093,9 +1093,10 @@
  	        			{
  	        				razonserv =razonserv;
  	        			}
- 	        			var prioridad =$("#prioridad").val();
- 	        			if(prioridad==""){$("#sec-prioridad").addClass("has-error"); bandvalida=false;}else{$("#sec-prioridad").removeClass("has-error");}
- 	        			var param = "accion=A";
+                                        var prioridad =$("#prioridad").val();
+                                        if(prioridad==""){$("#sec-prioridad").addClass("has-error"); bandvalida=false;}else{$("#sec-prioridad").removeClass("has-error");}
+                                        if($("#formtecnico").is(':hidden') && $("#frmtipomantenimiento").val()=="PREVENTIVO"){bandvalida=true;}
+                                        var param = "accion=A";
  	        			param += "&orden="+escape(forden)+"&tipomantenimiento="+escape(ftipomant)+"&empresa="+escape(fcliente)+"&ciudad="+escape(fciudad)+"&sucursal="+escape(fsucursal)+"&direccion="+escape(fdireccion)+"&gerente="+escape(fgerentesup)+"&fechareg="+escape(fechareg)+"&horareg="+escape(horareg)+"&usuario=<%=usuario%>&razonserv="+escape(razonserv)+"&prioridad="+escape(prioridad)+"&bandRazonserv="+bandRazonserv;
  	        			if(bandvalida)
  	        			{

--- a/jsp/tareasLiquidadas.jsp
+++ b/jsp/tareasLiquidadas.jsp
@@ -1091,9 +1091,10 @@
  	        			{
  	        				razonserv =razonserv;
  	        			}
- 	        			var prioridad =$("#prioridad").val();
- 	        			if(prioridad==""){$("#sec-prioridad").addClass("has-error"); bandvalida=false;}else{$("#sec-prioridad").removeClass("has-error");}
- 	        			var param = "accion=A";
+                                        var prioridad =$("#prioridad").val();
+                                        if(prioridad==""){$("#sec-prioridad").addClass("has-error"); bandvalida=false;}else{$("#sec-prioridad").removeClass("has-error");}
+                                        if($("#formtecnico").is(':hidden') && $("#frmtipomantenimiento").val()=="PREVENTIVO"){bandvalida=true;}
+                                        var param = "accion=A";
  	        			param += "&orden="+escape(forden)+"&tipomantenimiento="+escape(ftipomant)+"&empresa="+escape(fcliente)+"&ciudad="+escape(fciudad)+"&sucursal="+escape(fsucursal)+"&direccion="+escape(fdireccion)+"&gerente="+escape(fgerentesup)+"&fechareg="+escape(fechareg)+"&horareg="+escape(horareg)+"&usuario=<%=usuario%>&razonserv="+escape(razonserv)+"&prioridad="+escape(prioridad)+"&bandRazonserv="+bandRazonserv;
  	        			if(bandvalida)
  	        			{


### PR DESCRIPTION
## Summary
- Allow preventive maintenance tasks to bypass technical detail validation when the technical form is hidden
- Load resumenTareas action helpers across summary pages and provide fallback `cargaTareas` to avoid undefined function errors

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bfe5c1b108332a52b60d7d0689584