### PR TITLE
Allow preventive termination without technical fields

### DIFF
--- a/jsp/tareas.jsp
+++ b/jsp/tareas.jsp
@@ -171,7 +171,7 @@
 		<div class="col-xs-9">
 			<div class="row">
 			<div class="col-xs-12 col-sm-6">
-<!-- 				<input type="text" id="rango1" style="width:100%;" class="form-control" maxlength="4" placeholder="Mínimo"/> -->
+<!-- 				<input type="text" id="rango1" style="width:100%;" class="form-control" maxlength="4" placeholder="MÃ­nimo"/> -->
 				<div class='input-group date' id='fechainicio'>
                     <input type='text' class="form-control" />
                     <span class="input-group-addon">
@@ -180,7 +180,7 @@
                 </div>
 			</div>
 			<div class="col-xs-12 col-sm-6">
-<!-- 				<input type="text" id="rango2" style="width:100%;" class="form-control" maxlength="4" placeholder="Máximo"/> -->
+<!-- 				<input type="text" id="rango2" style="width:100%;" class="form-control" maxlength="4" placeholder="MÃ¡ximo"/> -->
 				<div class='input-group date' id='fechafin'>
                     <input type='text' class="form-control" />
                     <span class="input-group-addon">
@@ -287,18 +287,18 @@
 // 	            filteringType: "local",
 // 	            filteringCondition: "contains",
 // 	            highlightMatchesMode: "contains",
-// 	            placeHolder: "Buscar técnico...",
+// 	            placeHolder: "Buscar tÃ©cnico...",
 // 	            dropDownOrientation: "bottom"
 // // 	         	selectionChanged: storeTecnicos
 // 	        });
 // 		$("#selectTecnicoR").select2({
 // 			data:storeTecnicos,
-// 			placeholder: "Seleccione Técnico"
+// 			placeholder: "Seleccione TÃ©cnico"
 // 		});
 		
 // 		$("#selectTecnicoActual").select2({
 // 			data:storeTecnicoActual,
-// 			placeholder: "Seleccione Técnico"
+// 			placeholder: "Seleccione TÃ©cnico"
 // 		});
 
 		$('#fechainicio').datetimepicker(
@@ -477,7 +477,7 @@
     /**********************************************************************/ 
     function abrirASIGNAR(foliopisa,telefono,folioplex,expediente)
     {
-    	// En el parametro estado se le envia el estado en el que fue levantada la acción
+    	// En el parametro estado se le envia el estado en el que fue levantada la acciÃ³n
     	var parametros="";
     	if(tipoAccion == ""){
     		tipoAccion="Asignar";
@@ -507,7 +507,7 @@
     		  					if(resp.trim() == "COMPLETE"){
     		  						resp="LIQUIDADA";
     		  					}
-    		  					swal("", "No se pudo realizo la acción porque la tarea ya esta " + resp+".", "error");
+    		  					swal("", "No se pudo realizo la acciÃ³n porque la tarea ya esta " + resp+".", "error");
     		  					cargaTareas();
     		  				}
     		  				tipoAccion="";
@@ -528,7 +528,7 @@
             height: 400,
             width: 500,
             modal: true,
-            title: "Reasignación de Tarea",
+            title: "ReasignaciÃ³n de Tarea",
             buttons: [{
               text : "Aceptar",
               "class": "btn btn-primary",
@@ -540,13 +540,13 @@
   	  			if(expedienteNuevo!="" && expedienteNuevo!=undefined)
   	  			{
   	    	swal({
-  	    		title: "",  
-  	    		text: "¿Desea asignar la orden "+foliopisa+" al tecnico "+nombre+"?",     
-      			type: "info",   
-      			showCancelButton: true,   
+  	    		title: "",Â Â 
+  	    		text: "Â¿Desea asignar la orden "+foliopisa+" al tecnico "+nombre+"?", Â Â Â Â 
+      			type: "info", Â Â 
+      			showCancelButton: true, Â Â 
       			cancelButtonText: "Cancelar",
-      			confirmButtonColor: "#3a5a74",   
-      			confirmButtonText: "Aceptar",   
+      			confirmButtonColor: "#3a5a74", Â Â 
+      			confirmButtonText: "Aceptar", Â Â 
       			closeOnConfirm: false }, 
       			function(){
        				$.ajax({
@@ -558,12 +558,12 @@
                  				{
 			                 				
 			                 				swal({
-				            	    		title: "",  
-				            	    		text: "La asignación de tarea(s) fue satisfactoria.",   
-				                			type: "success",   
-				                			showCancelButton: false,   
-				                			confirmButtonColor: "#3a5a74",   
-				                			confirmButtonText: "Aceptar",   
+				            	    		title: "",Â Â 
+				            	    		text: "La asignaciÃ³n de tarea(s) fue satisfactoria.", Â Â 
+				                			type: "success", Â Â 
+				                			showCancelButton: false, Â Â 
+				                			confirmButtonColor: "#3a5a74", Â Â 
+				                			confirmButtonText: "Aceptar", Â Â 
 				                			closeOnConfirm: true }, 
 				                			function(){
 				                				//Borrar tarea del panel de Tareas
@@ -586,7 +586,7 @@
   	  }
   	  else
   		  {
-  		  swal("Debe seleccionar un técnico", "", "warning");
+  		  swal("Debe seleccionar un tÃ©cnico", "", "warning");
   		  }
 //             	  var expediente=$("#selectTecnico").find("option:selected").val();
 //             	  var nombre=$("#selectTecnicoR").find("option:selected").text();
@@ -595,13 +595,13 @@
 //             	  if(expediente!="")
 //             	  {
 //             	    	swal({
-//             	    		title: "",  
-//             	    		text: "Desea asignar la order "+folioplex+" al tecnico "+nombre+"?",    
-//                 			type: "info",   
-//                 			showCancelButton: true,   
+//             	    		title: "",Â Â 
+//             	    		text: "Desea asignar la order "+folioplex+" al tecnico "+nombre+"?", Â Â Â 
+//                 			type: "info", Â Â 
+//                 			showCancelButton: true, Â Â 
 //                 			cancelButtonText: "Cancelar",
-//                 			confirmButtonColor: "#3a5a74",   
-//                 			confirmButtonText: "Aceptar",   
+//                 			confirmButtonColor: "#3a5a74", Â Â 
+//                 			confirmButtonText: "Aceptar", Â Â 
 //                 			closeOnConfirm: true }, 
 //                 			function(){
 //                         				$.ajax({
@@ -660,7 +660,7 @@
 //             	  }
 //             	  else
 //             		  {
-//             		  swal("Debe seleccionar un técnico", "", "warning");
+//             		  swal("Debe seleccionar un tÃ©cnico", "", "warning");
 //             		  }
             	  
             	  }
@@ -687,16 +687,16 @@
 							if(resp.trim()=="OK")
     		  				{
     		  					swal({
-					    		title: "",  
-					    		text: "¿Desea despachar la orden: "+foliopisa+"?",      
-					    			type: "info",   
-					    			showCancelButton: true,   
+					    		title: "",Â Â 
+					    		text: "Â¿Desea despachar la orden: "+foliopisa+"?", Â Â  Â Â 
+					    			type: "info", Â Â 
+					    			showCancelButton: true, Â Â 
 					    			cancelButtonText: "Cancelar",
-					    			confirmButtonColor: "#3a5a74",    
-					    			confirmButtonText: "Aceptar",   
+					    			confirmButtonColor: "#3a5a74", Â Â Â 
+					    			confirmButtonText: "Aceptar", Â Â 
 					    			closeOnConfirm: true }, 
 					    			function(){
-					    				  var parametros="estado=DESPACHADA&tipo=DESPACHADA&folioplex="+folioplex+"&foliopisa="+foliopisa;
+					    				Â Â var parametros="estado=DESPACHADA&tipo=DESPACHADA&folioplex="+folioplex+"&foliopisa="+foliopisa;
 					    		    	$.ajax({
 					    		  			url: 'actualizaEstado.jsp?'+parametros,
 					    		  			type: "GET",
@@ -810,7 +810,7 @@
         autoOpen: false,
         height: 400,
         width: 350,
-        title: "Liquidación",
+        title: "LiquidaciÃ³n",
         modal: true
         });
     
@@ -871,7 +871,7 @@
     /***********************************/  
     function abrirOBJETAR(foliopisa,telefono,folioplex,expediente,estado)
     {
-		// En el parametro estado se le envia el estado en el que fue levantada la acción
+		// En el parametro estado se le envia el estado en el que fue levantada la acciÃ³n
     	var parametros = "folioplex="+folioplex+"&estado=DESPACHADA";
   		$.ajax({
 		url: "../ValidarEstadoTarea?"+parametros,
@@ -888,7 +888,7 @@
 	  					if(resp.trim() == "COMPLETE"){
 	  						resp="LIQUIDADA";
 	  					}
-	  					swal("", "No se pudo realizo la acción porque la tarea ya esta " + resp+".", "error");
+	  					swal("", "No se pudo realizo la acciÃ³n porque la tarea ya esta " + resp+".", "error");
 	  					cargaTareas();
 		  			}
 				}
@@ -907,13 +907,13 @@
   		  	{
     	
 		    	swal({
-		    		title: "",  
-		    		text: "¿Desea liquidar la orden: "+foliopisa+"?",   
-	    			type: "info",   
-	    			showCancelButton: true,   
+		    		title: "",Â Â 
+		    		text: "Â¿Desea liquidar la orden: "+foliopisa+"?", Â Â 
+	    			type: "info", Â Â 
+	    			showCancelButton: true, Â Â 
 	    			cancelButtonText: "Cancelar",
-	    			confirmButtonColor: "#3a5a74",    
-	    			confirmButtonText: "Liquidar",   
+	    			confirmButtonColor: "#3a5a74", Â Â Â 
+	    			confirmButtonText: "Liquidar", Â Â 
 	    			closeOnConfirm: true }, 
 	    			function(){
 	    				var parametros="estado=COMPLETE&tipo=COMPLETE&folioplex="+folioplex+"&foliopisa="+foliopisa;
@@ -1138,12 +1138,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Incidencia Capturada!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Incidencia Capturada!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1208,7 +1208,7 @@
     	var tituloform = "";
     	var alto = 0;
 
-    		tituloform = "Reasignar Técnico";
+    		tituloform = "Reasignar TÃ©cnico";
     		alto=h-150;
     		
     		if(w<600)
@@ -1261,12 +1261,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Incidencia Asignada!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Incidencia Asignada!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1324,7 +1324,7 @@
     	var tituloform = "";
     	var alto = 0;
 
-    		tituloform = "Asignar Técnico";
+    		tituloform = "Asignar TÃ©cnico";
     		alto=h-150;
     		if(w<600)
     		{
@@ -1374,12 +1374,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Incidencia Asignada!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Incidencia Asignada!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1487,12 +1487,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Trabajo en Curso!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Trabajo en Curso!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1576,55 +1576,60 @@
  	        [ 
  	        	{ id:"aceptarform","data-test":"data test", 
  	        		text: "Aceptar", 
- 	        		click:    function() {
- 	        			var bandvalida = true;
- 	        			var parmarca = $("#marca").val();
- 	        			if(parmarca==""){$("#sec-marca").addClass("has-error"); bandvalida=false;}else{$("#sec-marca").removeClass("has-error");}
+                                click:    function() {
+                                        var skipValid = ( $("#formtecnico").is(':hidden') && $("#frmtipomantenimiento").val() === "PREVENTIVO" );
+                                        var bandvalida = true;
+                                        var parmarca = $("#marca").val();
+                                        if(!skipValid && parmarca==""){$("#sec-marca").addClass("has-error"); bandvalida=false;}else{$("#sec-marca").removeClass("has-error");}
  	        			var parserie = $("#serie").val();  
 //  	        			if(parserie==""){$("#sec-serie").addClass("has-error"); bandvalida=false;}else{$("#sec-serie").removeClass("has-error");}
  	        			var parmodelo = $("#modelo").val();  
 //  	        			if(parmodelo==""){$("#sec-modelo").addClass("has-error"); bandvalida=false;}else{$("#sec-modelo").removeClass("has-error");}
- 	        			var parvoltaje = $("#voltaje").val();  
- 	        			if(parvoltaje==""){$("#sec-parvoltaje").addClass("has-error"); bandvalida=false;}else{$("#sec-parvoltaje").removeClass("has-error");}
- 	        			var paramperes = $("#amperes").val(); 
- 	        			if(paramperes==""){$("#sec-amperes").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes").removeClass("has-error");}
+                                        var parvoltaje = $("#voltaje").val();
+                                        if(!skipValid && parvoltaje==""){$("#sec-parvoltaje").addClass("has-error"); bandvalida=false;}else{$("#sec-parvoltaje").removeClass("has-error");}
+                                        var paramperes = $("#amperes").val();
+                                        if(!skipValid && paramperes==""){$("#sec-amperes").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes").removeClass("has-error");}
 //  	        			var parrazonserv = $("#razonserv").val();  
- 	        			var parservreal = $("#servreal option:selected").text();
- 	        			if(parservreal=="Seleccionar..."){$("#sec-servreal").addClass("has-error"); bandvalida=false;}else{$("#sec-servreal").removeClass("has-error");}
- 	        			var bandservreal = "";
- 	        			if(parservreal=="OTRO")
- 	        			{
- 	        				bandservreal ="S";
- 	        				parservreal=$("#otroServicioReal").val();  
- 	        				if(servreal==""){$("#sec-otroServicioReal").addClass("has-error"); bandvalida=false;}else{$("#sec-otroServicioReal").removeClass("has-error");}
- 	        			}
- 	        			var parcomentarios = $("#comentarios").val();  
- 	        			if(parcomentarios==""){$("#sec-comentarios").addClass("has-error"); bandvalida=false;}else{$("#sec-comentarios").removeClass("has-error");}
- 	        			var parcon1 = $("#cond1").val(); 
- 	        			if(parcon1==""){$("#sec-cond1").addClass("has-error"); bandvalida=false;}else{$("#sec-cond1").removeClass("has-error");}
-	 	   				var parcon2 = $("#cond2").val();  
-	 	   				if(parcon2==""){$("#sec-cond2").addClass("has-error"); bandvalida=false;}else{$("#sec-cond2").removeClass("has-error");}
-	 	   				var partempopera = $("#tempopera").val();  
-	 	   				if(partempopera==""){$("#sec-tempopera").addClass("has-error"); bandvalida=false;}else{$("#sec-tempopera").removeClass("has-error");}
-	 	   				var parvoltaje2 = $("#voltaje2").val(); 
-	 	   				if(parvoltaje2==""){$("#sec-voltaje2").addClass("has-error"); bandvalida=false;}else{$("#sec-voltaje2").removeClass("has-error");}
-	 	   				var paramperes2 = $("#amperes2").val();
-	 	   				if(paramperes2==""){$("#sec-amperes2").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes2").removeClass("has-error");}
+                                        var parservreal = $("#servreal option:selected").text();
+                                        if(parservreal=="Seleccionar...") parservreal="";
+                                        if(!skipValid && parservreal==""){$("#sec-servreal").addClass("has-error"); bandvalida=false;}else{$("#sec-servreal").removeClass("has-error");}
+                                        var bandservreal = "";
+                                        if(parservreal=="OTRO")
+                                        {
+                                                bandservreal ="S";
+                                                parservreal=$("#otroServicioReal").val();
+                                                if(!skipValid && parservreal==""){$("#sec-otroServicioReal").addClass("has-error"); bandvalida=false;}else{$("#sec-otroServicioReal").removeClass("has-error");}
+                                        }
+                                        var parcomentarios = $("#comentarios").val();
+                                        if(!skipValid && parcomentarios==""){$("#sec-comentarios").addClass("has-error"); bandvalida=false;}else{$("#sec-comentarios").removeClass("has-error");}
+                                        var parcon1 = $("#cond1").val();
+                                        if(!skipValid && parcon1==""){$("#sec-cond1").addClass("has-error"); bandvalida=false;}else{$("#sec-cond1").removeClass("has-error");}
+                                                var parcon2 = $("#cond2").val();
+                                                if(!skipValid && parcon2==""){$("#sec-cond2").addClass("has-error"); bandvalida=false;}else{$("#sec-cond2").removeClass("has-error");}
+                                                var partempopera = $("#tempopera").val();
+                                                if(!skipValid && partempopera==""){$("#sec-tempopera").addClass("has-error"); bandvalida=false;}else{$("#sec-tempopera").removeClass("has-error");}
+                                                var parvoltaje2 = $("#voltaje2").val();
+                                                if(!skipValid && parvoltaje2==""){$("#sec-voltaje2").addClass("has-error"); bandvalida=false;}else{$("#sec-voltaje2").removeClass("has-error");}
+                                                var paramperes2 = $("#amperes2").val();
+                                                if(!skipValid && paramperes2==""){$("#sec-amperes2").addClass("has-error"); bandvalida=false;}else{$("#sec-amperes2").removeClass("has-error");}
 	 	   				var partenicoserv = $("#tenicoserv").val();
 // 	 	   				if(partenicoserv==""){$("#sec-tenicoserv").addClass("has-error"); bandvalida=false;}else{$("#sec-tenicoserv").removeClass("has-error");}
-	 	   				var parnombreequipo =$("#nombreequipo option:selected").text();
-	 	   				if(parnombreequipo=="Seleccionar..."){$("#sec-nombreequipo").addClass("has-error"); bandvalida=false;}else{$("#sec-nombreequipo").removeClass("has-error");}
-	 	   				var bandEquipo ="";
-	 	   				if(parnombreequipo=="OTRO")
-	 	   				{
-	 	   				bandEquipo= "S";
-	 	   				parnombreequipo =$("#otroNombreEquipo").val();
-	 	   				if(parnombreequipo==""){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
-	 	   				}
-	 	   				var parservterminado = $('input[name=servterminado]:checked').val();
-	 	   				var partempounidad = $('input[name=tempounidad]:checked').val();
-	 	   				if(partempounidad==undefined){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
-	 	   			    if(parservterminado==undefined){parservterminado=""}
+                                                var parnombreequipo =$("#nombreequipo option:selected").text();
+                                                if(parnombreequipo=="Seleccionar...") parnombreequipo="";
+                                                if(!skipValid && parnombreequipo==""){$("#sec-nombreequipo").addClass("has-error"); bandvalida=false;}else{$("#sec-nombreequipo").removeClass("has-error");}
+                                                var bandEquipo ="";
+                                                if(parnombreequipo=="OTRO")
+                                                {
+                                                bandEquipo= "S";
+                                                parnombreequipo =$("#otroNombreEquipo").val();
+                                                if(!skipValid && parnombreequipo==""){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
+                                                }
+                                                var parservterminado = $('input[name=servterminado]:checked').val();
+                                                var partempounidad = $('input[name=tempounidad]:checked').val();
+                                                if(skipValid){partempounidad="";$("#sec-otroNombreEquipo").removeClass("has-error");}
+                                                else if(partempounidad==undefined){$("#sec-otroNombreEquipo").addClass("has-error"); bandvalida=false;}else{$("#sec-otroNombreEquipo").removeClass("has-error");}
+                                            if(parservterminado==undefined){parservterminado=""}
+                                            if(partempounidad==undefined){partempounidad=""}
  	        			var param = "accion=TERMINAR";
  	        			param += "&orden="+escape(idorden)+"&marca="+escape(parmarca)+"&serie="+escape(parserie)+"&modelo="+escape(parmodelo)+"&voltaje="+escape(parvoltaje)+"&amperes="+escape(paramperes)+"&servreal="+escape(parservreal)+"&comentarios="+escape(parcomentarios);
  	        			param += "&cond1="+escape(parcon1)+"&cond2="+escape(parcon2)+"&tempopera="+escape(partempopera)+"&voltaje2="+escape(parvoltaje2)+"&amperes2="+escape(paramperes2)+"&tenicoserv="+escape(partenicoserv)+"&servterminado="+escape(parservterminado)+"&usuario=<%=usuario%>&nombreequipo="+escape(parnombreequipo)+"&tempounidad="+partempounidad+"&bandservreal="+bandservreal+"&bandEquipo="+bandEquipo+"&estatus="+sigestatus+"&actualestatus="+actualestatus+"&idaccion="+idaccion;
@@ -1651,12 +1656,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Trabajo Terminado!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Trabajo Terminado!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1779,12 +1784,12 @@
  											{
  												$("#container").mLoading("hide");
  												swal({
- 						            	    		title: "",  
- 						            	    		text: "Trabajo Suspendido!.",   
- 						                			type: "success",   
- 						                			showCancelButton: false,   
- 						                			confirmButtonColor: "#3a5a74",   
- 						                			confirmButtonText: "Aceptar",   
+ 						            	    		title: "",Â Â 
+ 						            	    		text: "Trabajo Suspendido!.", Â Â 
+ 						                			type: "success", Â Â 
+ 						                			showCancelButton: false, Â Â 
+ 						                			confirmButtonColor: "#3a5a74", Â Â 
+ 						                			confirmButtonText: "Aceptar", Â Â 
  						                			closeOnConfirm: true }, 
  						                			function(){
  						                				cargaTareas();
@@ -1843,13 +1848,13 @@
     function realizaREANUDAR(idorden,ordenserv, sigestatus,actualestatus,idaccion)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea reanudar el trabajo "+ordenserv+"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea reanudar el trabajo "+ordenserv+"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Cancelar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   				var param="accion=REANUDAR";
@@ -1875,12 +1880,12 @@
 										if(item.resp=="OK")
 										{
 											swal({
-					            	    		title: "",  
-					            	    		text: "Trabajo Reanudado!.",   
-					                			type: "success",   
-					                			showCancelButton: false,   
-					                			confirmButtonColor: "#3a5a74",   
-					                			confirmButtonText: "Aceptar",   
+					            	    		title: "",Â Â 
+					            	    		text: "Trabajo Reanudado!.", Â Â 
+					                			type: "success", Â Â 
+					                			showCancelButton: false, Â Â 
+					                			confirmButtonColor: "#3a5a74", Â Â 
+					                			confirmButtonText: "Aceptar", Â Â 
 					                			closeOnConfirm: true }, 
 					                			function(){
 					                				cargaTareas();
@@ -1909,13 +1914,13 @@
     function realizaCERRAR(idorden,ordenserv,sigestatus,actualestatus,idaccion)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea cerrar el trabajo "+ordenserv+"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea cerrar el trabajo "+ordenserv+"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Cancelar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   			
@@ -1942,12 +1947,12 @@
 										if(item.resp=="OK")
 										{
 											swal({
-					            	    		title: "",  
-					            	    		text: "Trabajo Cerrado!.",   
-					                			type: "success",   
-					                			showCancelButton: false,   
-					                			confirmButtonColor: "#3a5a74",   
-					                			confirmButtonText: "Aceptar",   
+					            	    		title: "",Â Â 
+					            	    		text: "Trabajo Cerrado!.", Â Â 
+					                			type: "success", Â Â 
+					                			showCancelButton: false, Â Â 
+					                			confirmButtonColor: "#3a5a74", Â Â 
+					                			confirmButtonText: "Aceptar", Â Â 
 					                			closeOnConfirm: true }, 
 					                			function(){
 					                				cargaTareas();
@@ -1977,13 +1982,13 @@
     function realizaELIMINAR(idorden,ordenserv,sigestatus,actualestatus,idaccion)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea eliminar el trabajo "+ordenserv+"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea eliminar el trabajo "+ordenserv+"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Eliminar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   			
@@ -2010,12 +2015,12 @@
 										if(item.resp=="OK")
 										{
 											swal({
-					            	    		title: "",  
-					            	    		text: "Trabajo Eliminado!.",   
-					                			type: "success",   
-					                			showCancelButton: false,   
-					                			confirmButtonColor: "#3a5a74",   
-					                			confirmButtonText: "Aceptar",   
+					            	    		title: "",Â Â 
+					            	    		text: "Trabajo Eliminado!.", Â Â 
+					                			type: "success", Â Â 
+					                			showCancelButton: false, Â Â 
+					                			confirmButtonColor: "#3a5a74", Â Â 
+					                			confirmButtonText: "Aceptar", Â Â 
 					                			closeOnConfirm: true }, 
 					                			function(){
 					                				cargaTareas();
@@ -2100,12 +2105,12 @@
  	   										{
  	   										$("#container").mLoading("hide");
  	   											swal({
- 	   					            	    		title: "",  
- 	   					            	    		text: "El trabajo ya puede ser terminado!.",   
- 	   					                			type: "success",   
- 	   					                			showCancelButton: false,   
- 	   					                			confirmButtonColor: "#3a5a74",   
- 	   					                			confirmButtonText: "Aceptar",   
+ 	   					            	    		title: "",Â Â 
+ 	   					            	    		text: "El trabajo ya puede ser terminado!.", Â Â 
+ 	   					                			type: "success", Â Â 
+ 	   					                			showCancelButton: false, Â Â 
+ 	   					                			confirmButtonColor: "#3a5a74", Â Â 
+ 	   					                			confirmButtonText: "Aceptar", Â Â 
  	   					                			closeOnConfirm: true }, 
  	   					                			function(){
  	   					                				modaldialog.dialog( "close" ); 
@@ -2132,7 +2137,7 @@
  	        			}
  	        			else
  	        			{
- 	        				swal("", "Debe seleccionar la confirmación para autorizar!", "error");
+ 	        				swal("", "Debe seleccionar la confirmaciÃ³n para autorizar!", "error");
  	        			}
  	        			
  	        			},
@@ -2227,13 +2232,13 @@
     function eliminarfactura(idfactura, foliofactura, proveedor)
     {
     	swal({
-	    		title: "",  
-	    		text: "¿Desea eliminar la factura \""+foliofactura+"\" del proveedor \""+proveedor+"\"?",     
-  			type: "info",   
-  			showCancelButton: true,   
+	    		title: "",Â Â 
+	    		text: "Â¿Desea eliminar la factura \""+foliofactura+"\" del proveedor \""+proveedor+"\"?", Â Â Â Â 
+  			type: "info", Â Â 
+  			showCancelButton: true, Â Â 
   			cancelButtonText: "Cancelar",
-  			confirmButtonColor: "#3a5a74",   
-  			confirmButtonText: "Aceptar",   
+  			confirmButtonColor: "#3a5a74", Â Â 
+  			confirmButtonText: "Aceptar", Â Â 
   			closeOnConfirm: false }, 
   			function(){
   				param="accion=ELIMINARFACT&idfactura="+idfactura;


### PR DESCRIPTION
## Summary
- Bypass form validation when technical section is hidden and maintenance type is PREVENTIVO, allowing termination without filling technical fields

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c09d86a1c8332a7c9afb478791b55