### PR TITLE
Ensure preventive maintenance forms pre-populate fields

### DIFF
--- a/jsp/formTerminar.jsp
+++ b/jsp/formTerminar.jsp
@@ -307,24 +307,22 @@
         var equiposlista = $.parseJSON('<%= (equipos != null) ? equipos.toString() : "[]" %>');
          $(document).ready(function() {
 
-                        if($('#frmtipomantenimiento').val() === 'PREVENTIVO'){
-                                $('#formtecnico').hide();
-                                $('#maintenanceTabs').show();
-                                $('#loadingfrm').css('height','60%');
-                                var orden = encodeURIComponent($('#frmordenServicio').val());
-                                var cliente = encodeURIComponent($('#frmcliente').val());
-                                $('#tabAire').attr('src', '../maintenance-form?orden=' + orden + '&cliente=' + cliente);
-                                $('#tabRefrigeracion').attr('src', '../refrigeracion-form?orden=' + orden + '&cliente=' + cliente);
-                                $('#aceptarform').on('mousedown', function(){
-                                        $('#marca, #serie, #modelo, #comentarios, #tenicoserv').val('NA');
-                                        $('#cond1, #cond2').val('0');
-                                        $('#voltaje, #amperes, #tempopera, #voltaje2, #amperes2').val('0');
-                                        $('#servreal').prop('selectedIndex',1);
-                                        $('#nombreequipo').prop('selectedIndex',1);
-                                        $('input[name=servterminado]').first().prop('checked',true);
-                                        $('input[name=tempounidad]').first().prop('checked',true);
-                                });
-                        }
+                       if($('#frmtipomantenimiento').val() === 'PREVENTIVO'){
+                               $('#formtecnico').hide();
+                               $('#maintenanceTabs').show();
+                               $('#loadingfrm').css('height','60%');
+                               var orden = encodeURIComponent($('#frmordenServicio').val());
+                               var cliente = encodeURIComponent($('#frmcliente').val());
+                               $('#tabAire').attr('src', '../maintenance-form?orden=' + orden + '&cliente=' + cliente);
+                               $('#tabRefrigeracion').attr('src', '../refrigeracion-form?orden=' + orden + '&cliente=' + cliente);
+                               $('#marca, #serie, #modelo, #comentarios, #tenicoserv').val('NA');
+                               $('#cond1, #cond2').val('0');
+                               $('#voltaje, #amperes, #tempopera, #voltaje2, #amperes2').val('0');
+                               $('#servreal').prop('selectedIndex',1);
+                               $('#nombreequipo').prop('selectedIndex',1);
+                               $('input[name=servterminado]').first().prop('checked',true);
+                               $('input[name=tempounidad]').first().prop('checked',true);
+                       }
 
                         $('#tabAireLink').on('click', function(e){
                                 e.preventDefault();

--- a/jsp/formTerminarMovil.jsp
+++ b/jsp/formTerminarMovil.jsp
@@ -548,17 +548,15 @@
                                 $("#frmultimotec").attr('disabled','disabled');
                         }
 
-                        if($('#formtecnico').is(':hidden') && $('#frmtipomantenimiento').val() === 'PREVENTIVO'){
-                                $('#aceptarform').on('mousedown', function(){
-                                        $('#marca, #serie, #modelo, #comentarios, #tenicoserv').val('NA');
-                                        $('#cond1, #cond2').val('0');
-                                        $('#voltaje, #amperes, #tempopera, #voltaje2, #amperes2').val('0');
-                                        $('#servreal').prop('selectedIndex',1);
-                                        $('#nombreequipo').prop('selectedIndex',1);
-                                        $('input[name=servterminado]').first().prop('checked',true);
-                                        $('input[name=tempounidad]').first().prop('checked',true);
-                                });
-                        }
+                       if($('#formtecnico').is(':hidden') && $('#frmtipomantenimiento').val() === 'PREVENTIVO'){
+                               $('#marca, #serie, #modelo, #comentarios, #tenicoserv').val('NA');
+                               $('#cond1, #cond2').val('0');
+                               $('#voltaje, #amperes, #tempopera, #voltaje2, #amperes2').val('0');
+                               $('#servreal').prop('selectedIndex',1);
+                               $('#nombreequipo').prop('selectedIndex',1);
+                               $('input[name=servterminado]').first().prop('checked',true);
+                               $('input[name=tempounidad]').first().prop('checked',true);
+                       }
 
 
                  consultaFacturas("C");


### PR DESCRIPTION
## Summary
- Pre-fill default values when preventive maintenance forms load instead of waiting for button press

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c15a7217c8332be8ba463b5a43e63