### PR TITLE
Default values for hidden tecnico form

### DIFF
--- a/jsp/formTerminar.jsp
+++ b/jsp/formTerminar.jsp
@@ -315,13 +315,13 @@
                                var cliente = encodeURIComponent($('#frmcliente').val());
                                $('#tabAire').attr('src', '../maintenance-form?orden=' + orden + '&cliente=' + cliente);
                                $('#tabRefrigeracion').attr('src', '../refrigeracion-form?orden=' + orden + '&cliente=' + cliente);
-                               $('#marca, #serie, #modelo, #comentarios, #tenicoserv').val('NA');
-                               $('#cond1, #cond2').val('0');
-                               $('#voltaje, #amperes, #tempopera, #voltaje2, #amperes2').val('0');
-                               $('#servreal').prop('selectedIndex',1);
-                               $('#nombreequipo').prop('selectedIndex',1);
-                               $('input[name=servterminado]').first().prop('checked',true);
-                               $('input[name=tempounidad]').first().prop('checked',true);
+                       }
+
+                       if ($('#formtecnico').is(':hidden') && $('#frmtipomantenimiento').val() === 'PREVENTIVO') {
+                               $('#marca, #serie, #modelo, #comentarios, #tenicoserv, #otroNombreEquipo, #otroServicioReal').val('NA');
+                               $('#cond1, #cond2, #voltaje, #amperes, #tempopera, #voltaje2, #amperes2').val('0');
+                               $('#servreal, #nombreequipo').prop('selectedIndex', 1);
+                               $('input[name=servterminado], input[name=tempounidad]').first().prop('checked', true);
                        }
 
                         $('#tabAireLink').on('click', function(e){


### PR DESCRIPTION
## Summary
- Populate technical form with placeholder data when maintenance type is PREVENTIVO and form is hidden

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c1c90e9bc833290f5f137ff690a72