### PR TITLE
Add PDF downloads for maintenance and refrigeration forms

### DIFF
--- a/jsp/MaintenanceForm.jsp
+++ b/jsp/MaintenanceForm.jsp
@@ -13,6 +13,8 @@
     <link href="../assets/font-awesome/css/font-awesome.css" rel="stylesheet" />
     <link href="../assets/css/style.css" rel="stylesheet">
     <link href="../assets/css/style-responsive.css" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </head>
 <body>
 
@@ -37,6 +39,7 @@
 
     <div class="my-4 text-center">
         <button type="submit" id="saveButton" class="btn btn-primary" disabled>Guardar</button>
+        <button type="button" id="downloadPdf" class="btn btn-secondary ms-2">Descargar PDF</button>
     </div>
 
 </div>
@@ -77,6 +80,35 @@ document.addEventListener('DOMContentLoaded', async function () {
         const text = await resp.text();
         alert(text);
     });
+
+    const pdfBtn = document.getElementById('downloadPdf');
+    if (pdfBtn) {
+        pdfBtn.addEventListener('click', function () {
+            const { jsPDF } = window.jspdf;
+            html2canvas(form).then(canvas => {
+                const imgData = canvas.toDataURL('image/png');
+                const pdf = new jsPDF('p', 'pt', 'a4');
+                const pdfWidth = pdf.internal.pageSize.getWidth();
+                const pdfHeight = pdf.internal.pageSize.getHeight();
+                const imgWidth = canvas.width;
+                const imgHeight = canvas.height * pdfWidth / imgWidth;
+                let heightLeft = imgHeight;
+                let position = 0;
+
+                pdf.addImage(imgData, 'PNG', 0, position, pdfWidth, imgHeight);
+                heightLeft -= pdfHeight;
+
+                while (heightLeft > 0) {
+                    position = heightLeft - imgHeight;
+                    pdf.addPage();
+                    pdf.addImage(imgData, 'PNG', 0, position, pdfWidth, imgHeight);
+                    heightLeft -= pdfHeight;
+                }
+
+                pdf.save('maintenance-form.pdf');
+            });
+        });
+    }
 });
 </script>
 </body>

--- a/jsp/MaintenanceFormRefrigeracion.jsp
+++ b/jsp/MaintenanceFormRefrigeracion.jsp
@@ -13,6 +13,8 @@
     <link href="../assets/font-awesome/css/font-awesome.css" rel="stylesheet" />
     <link href="../assets/css/style.css" rel="stylesheet">
     <link href="../assets/css/style-responsive.css" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </head>
 <body>
 
@@ -38,6 +40,7 @@
 
     <div class="my-4 text-center">
         <button type="submit" id="saveButton" class="btn btn-primary" disabled>Guardar</button>
+        <button type="button" id="downloadPdf" class="btn btn-secondary ms-2">Descargar PDF</button>
     </div>
 
 </div>
@@ -73,11 +76,41 @@ document.addEventListener('DOMContentLoaded', async function () {
 
     form.addEventListener('submit', async function (e) {
         e.preventDefault();
-        const formData = new FormData(form);
-        const resp = await fetch(form.action, { method: 'POST', body: formData });
-        const text = await resp.text();
-        alert(text);
+       const formData = new FormData(form);
+       const resp = await fetch(form.action, { method: 'POST', body: formData });
+       const text = await resp.text();
+       alert(text);
     });
+
+    const pdfBtn = document.getElementById('downloadPdf');
+    if (pdfBtn) {
+        pdfBtn.addEventListener('click', function () {
+            const { jsPDF } = window.jspdf;
+            html2canvas(form).then(canvas => {
+                const imgData = canvas.toDataURL('image/png');
+                const pdf = new jsPDF('p', 'pt', 'a4');
+                const pdfWidth = pdf.internal.pageSize.getWidth();
+                const pdfHeight = pdf.internal.pageSize.getHeight();
+                const imgWidth = canvas.width;
+                const imgHeight = canvas.height * pdfWidth / imgWidth;
+                let heightLeft = imgHeight;
+                let position = 0;
+
+                pdf.addImage(imgData, 'PNG', 0, position, pdfWidth, imgHeight);
+                heightLeft -= pdfHeight;
+
+                while (heightLeft > 0) {
+                    position = heightLeft - imgHeight;
+                    pdf.addPage();
+                    pdf.addImage(imgData, 'PNG', 0, position, pdfWidth, imgHeight);
+                    heightLeft -= pdfHeight;
+                }
+
+                const ordenValue = ordenInput && ordenInput.value ? `-${ordenInput.value}` : '';
+                pdf.save(`refrigeracion-form${ordenValue}.pdf`);
+            });
+        });
+    }
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- allow maintenance form to be exported as PDF by integrating html2canvas and jsPDF and adding a download button
- enable refrigeration maintenance form PDF download with same tooling and handler
- ensure PDF exports span multiple pages and include service order ID in the refrigeration file name

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node test/tests.js` *(fails: ReferenceError: $ is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689ccc7c9b048332bf83b4e6a4ebccae