### PR TITLE
Hide form buttons from generated PDFs and append order ID

### DIFF
--- a/jsp/MaintenanceForm.jsp
+++ b/jsp/MaintenanceForm.jsp
@@ -38,8 +38,8 @@
     <jsp:include page="checklist/aireCondicionado/SignatureSection.jsp" />
 
     <div class="my-4 text-center">
-        <button type="submit" id="saveButton" class="btn btn-primary" disabled>Guardar</button>
-        <button type="button" id="downloadPdf" class="btn btn-secondary ms-2">Descargar PDF</button>
+        <button type="submit" id="saveButton" class="btn btn-primary" disabled data-html2canvas-ignore="true">Guardar</button>
+        <button type="button" id="downloadPdf" class="btn btn-secondary ms-2" data-html2canvas-ignore="true">Descargar PDF</button>
     </div>
 
 </div>

--- a/jsp/MaintenanceFormRefrigeracion.jsp
+++ b/jsp/MaintenanceFormRefrigeracion.jsp
@@ -39,8 +39,8 @@
     <jsp:include page="checklist/refrigeracion/SignatureSection.jsp" />
 
     <div class="my-4 text-center">
-        <button type="submit" id="saveButton" class="btn btn-primary" disabled>Guardar</button>
-        <button type="button" id="downloadPdf" class="btn btn-secondary ms-2">Descargar PDF</button>
+        <button type="submit" id="saveButton" class="btn btn-primary" disabled data-html2canvas-ignore="true">Guardar</button>
+        <button type="button" id="downloadPdf" class="btn btn-secondary ms-2" data-html2canvas-ignore="true">Descargar PDF</button>
     </div>
 
 </div>
@@ -107,7 +107,7 @@ const pdfBtn = document.getElementById('downloadPdf');
                 }
 
                 const ordenValue = ordenInput && ordenInput.value ? `-${ordenInput.value}` : '';
-                pdf.save('refrigeracion-form${ordenValue}.pdf');
+                pdf.save(`refrigeracion-form${ordenValue}.pdf`);
             });
         });
     }


### PR DESCRIPTION
## Summary
- exclude Save and PDF buttons from html2canvas capture so they don't appear in generated PDFs
- ensure refrigeration form PDF filename includes the `ordenServicio` value

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b49b63d483328da79f8ea38944c7