### PR TITLE
Fix missing parameter bindings in GestionTareasFix

### DIFF
--- a/src/bean/GestionTareasFix.java
+++ b/src/bean/GestionTareasFix.java
@@ -75,9 +75,15 @@ public class GestionTareasFix {
                 ps.setString(++idx, zona);
                 ps.setString(++idx, fechaini);
                 ps.setString(++idx, fechafin);
+                ps.setString(++idx, zona);
+                ps.setString(++idx, fechaini);
+                ps.setString(++idx, fechafin);
                 // idPerfil for technicians
                 ps.setString(++idx, "1");
                 // Second select for unassigned tasks
+                ps.setString(++idx, zona);
+                ps.setString(++idx, fechaini);
+                ps.setString(++idx, fechafin);
                 ps.setString(++idx, zona);
                 ps.setString(++idx, fechaini);
                 ps.setString(++idx, fechafin);


### PR DESCRIPTION
## Summary
- Add missing parameter bindings for TotalRendimTec function in GestionTareasFix to match SQL placeholders

## Testing
- `javac src/bean/GestionTareasFix.java` *(fails: package org.json does not exist, cannot find symbol Conexion, JSONArray, JSONObject)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c6f83b288332947f4e16acb72cdf