### PR TITLE
Fix parameter issues in GestionTareasFix

### DIFF
--- a/src/bean/GestionTareasFix.java
+++ b/src/bean/GestionTareasFix.java
@@ -17,11 +17,14 @@ import org.json.JSONObject;
  */
 public class GestionTareasFix {
     public JSONArray consultaTecnicoVisor(String zona, String fechaini, String fechafin) {
-        // Normalise the optional parameters
-        if ("0".equals(zona)) {
-            zona = "";
+        // Normalise the optional parameters.  The zone parameter is
+        // expected to be numeric by the stored functions used below.  An
+        // empty string causes MySQL to raise "Incorrect integer value: '' for
+        // column 'Zona'".  When the caller provides `null`, an empty value or
+        // "0" (meaning all zones) we pass "0" to avoid that error.
+        if (zona == null || zona.trim().isEmpty() || "0".equals(zona)) {
+            zona = "0";
         }
-        if (zona == null) zona = "";
         if (fechaini == null) fechaini = "";
         if (fechafin == null) fechafin = "";
 
@@ -75,9 +78,15 @@ public class GestionTareasFix {
                 ps.setString(++idx, zona);
                 ps.setString(++idx, fechaini);
                 ps.setString(++idx, fechafin);
+                ps.setString(++idx, zona);
+                ps.setString(++idx, fechaini);
+                ps.setString(++idx, fechafin);
                 // idPerfil for technicians
                 ps.setString(++idx, "1");
                 // Second select for unassigned tasks
+                ps.setString(++idx, zona);
+                ps.setString(++idx, fechaini);
+                ps.setString(++idx, fechafin);
                 ps.setString(++idx, zona);
                 ps.setString(++idx, fechaini);
                 ps.setString(++idx, fechafin);


### PR DESCRIPTION
## Summary
- Add missing parameter bindings for TotalRendimTec function in GestionTareasFix to match SQL placeholders
- Normalize blank or null zone inputs to numeric zero to avoid MySQL `Incorrect integer value` errors

## Testing
- `javac src/bean/GestionTareasFix.java` *(fails: package org.json does not exist, cannot find symbol Conexion, JSONArray, JSONObject)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c6f83b288332947f4e16acb72cdf