### PR TITLE
Fix unmatched brace causing JSP syntax error

### DIFF
--- a/jsp/usuarios_resumen.jsp
+++ b/jsp/usuarios_resumen.jsp
@@ -377,12 +377,11 @@ $(function() {
 						}
 					%>
 
-					<TR valign="middle" class="<%=bgcolor%>">
-						<TD colspan="26">&nbsp;</TD>
-					</TR>
-					<%
-						}
-                                                                                                 }
+                                        <TR valign="middle" class="<%=bgcolor%>">
+                                                <TD colspan="26">&nbsp;</TD>
+                                        </TR>
+                                        <%
+                                                }
                                         %>
                                 </tbody>
                         <% } else { %>


### PR DESCRIPTION
## Summary
- remove an extraneous closing brace in `usuarios_resumen.jsp` to pair the `if/else` block correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a68b87cc8332939a64c69a026413