### PR TITLE
Add confirmation flow when reopening incidents

### DIFF
--- a/jsp/reanudarIncidencia.jsp
+++ b/jsp/reanudarIncidencia.jsp
@@ -1,0 +1,41 @@
+<%@page import="org.json.JSONObject" %>
+<%@page import="org.json.JSONArray" %>
+<%@page import="bean.GestionTareas" %>
+<%@ page language="java" contentType="application/json; charset=ISO-8859-1"
+    pageEncoding="ISO-8859-1"%>
+<%
+        String orden = request.getParameter("orden");
+        String usuario = request.getParameter("usuario") != null ? request.getParameter("usuario") : "";
+        String estatus = request.getParameter("estatus");
+        String actualestatus = request.getParameter("actualestatus") != null ? request.getParameter("actualestatus") : "";
+        String idaccion = request.getParameter("idaccion");
+
+        JSONArray respuesta = new JSONArray();
+
+        try {
+                if (orden == null || orden.trim().isEmpty()) {
+                        JSONObject error = new JSONObject();
+                        error.put("resp", "ERROR");
+                        error.put("mensaje", "Identificador de orden no proporcionado.");
+                        respuesta.put(error);
+                } else {
+                        if (estatus == null || estatus.trim().isEmpty()) {
+                                estatus = "2";
+                        }
+                        if (idaccion == null || idaccion.trim().isEmpty()) {
+                                idaccion = "REANUDAR";
+                        }
+
+                        GestionTareas gestion = new GestionTareas();
+                        respuesta = gestion.reanudarTarea(orden, usuario, estatus, actualestatus, idaccion);
+                }
+        } catch (Exception ex) {
+                JSONObject error = new JSONObject();
+                error.put("resp", "ERROR");
+                error.put("mensaje", ex.getMessage() != null ? ex.getMessage() : "Error al reabrir la incidencia.");
+                respuesta = new JSONArray();
+                respuesta.put(error);
+        }
+
+        out.print(respuesta.toString());
+%>


### PR DESCRIPTION
## Summary
- add a confirmation modal and AJAX logic in `detalle.jsp` to reopen incidents and restore the status when cancelled
- expose a small JSP endpoint that calls `GestionTareas.reanudarTarea` with status 2 to persist the reopening

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf19f43b048332aa89ccff8cdbb062