### PR TITLE
Add confirmation flow when reopening incidents

### DIFF
--- a/jsp/detalle.jsp
+++ b/jsp/detalle.jsp
@@ -26,9 +26,170 @@
     
 
 %>
+<style type="text/css">
+#reabrir-modal-overlay {
+        background-color: rgba(0, 0, 0, 0.45);
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        display: none;
+        z-index: 1050;
+}
+
+#reabrir-modal {
+        background-color: #ffffff;
+        border-radius: 4px;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+        margin: 10% auto;
+        max-width: 420px;
+        padding: 20px;
+}
+
+#reabrir-modal h4 {
+        font-size: 16px;
+        font-weight: bold;
+        margin: 0 0 10px 0;
+}
+
+#reabrir-modal p {
+        margin: 0;
+        font-size: 13px;
+}
+
+#reabrir-modal .modal-actions {
+        margin-top: 20px;
+        text-align: right;
+}
+
+#reabrir-modal .modal-actions button {
+        margin-left: 10px;
+        min-width: 90px;
+}
+</style>
 <script type="text/javascript">
-$(document).ready(function() {
-	$("#container").mLoading("hide");
+document.addEventListener('DOMContentLoaded', function() {
+        var statusInput = document.getElementById('frmestatus');
+        var reopenSelect = document.getElementById('frmreabririncidencia');
+        var modalOverlay = document.getElementById('reabrir-modal-overlay');
+        var cancelButton = document.getElementById('reabrirCancelar');
+        var acceptButton = document.getElementById('reabrirAceptar');
+        var originalStatus = statusInput ? statusInput.value : '';
+
+        function showReopenModal() {
+                if (modalOverlay) {
+                        modalOverlay.style.display = 'block';
+                }
+        }
+
+        function hideReopenModal(resetSelection) {
+                if (modalOverlay) {
+                        modalOverlay.style.display = 'none';
+                }
+
+                if (resetSelection) {
+                        if (reopenSelect) {
+                                reopenSelect.value = '';
+                        }
+
+                        if (statusInput) {
+                                statusInput.value = originalStatus;
+                        }
+                }
+        }
+
+        function handleReopenError() {
+                hideReopenModal(true);
+                window.alert('No fue posible reabrir la incidencia. Intente nuevamente.');
+        }
+
+        if (reopenSelect) {
+                reopenSelect.addEventListener('change', function() {
+                        if (this.value === 'SI') {
+                                if (statusInput) {
+                                        statusInput.value = 'ASIGNADO';
+                                }
+
+                                showReopenModal();
+                        } else {
+                                if (statusInput) {
+                                        statusInput.value = originalStatus;
+                                }
+                        }
+                });
+        }
+
+        if (cancelButton) {
+                cancelButton.addEventListener('click', function() {
+                        hideReopenModal(true);
+                });
+        }
+
+        if (acceptButton) {
+                acceptButton.addEventListener('click', function() {
+                        if (acceptButton.hasAttribute('disabled')) {
+                                return;
+                        }
+
+                        acceptButton.setAttribute('disabled', 'disabled');
+
+                        var params = [
+                                'orden=' + encodeURIComponent('<%=idorden%>'),
+                                'usuario=' + encodeURIComponent('<%=usuario%>'),
+                                'estatus=2',
+                                'actualestatus=' + encodeURIComponent(originalStatus),
+                                'idaccion=REANUDAR'
+                        ].join('&');
+
+                        var xhr = new XMLHttpRequest();
+                        xhr.open('POST', 'reanudarIncidencia.jsp', true);
+                        xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=ISO-8859-1');
+
+                        xhr.onreadystatechange = function() {
+                                if (xhr.readyState !== 4) {
+                                        return;
+                                }
+
+                                acceptButton.removeAttribute('disabled');
+
+                                if (xhr.status >= 200 && xhr.status < 300) {
+                                        try {
+                                                var response = JSON.parse(xhr.responseText);
+                                                var reopenSuccessful = false;
+
+                                                if (Array.isArray(response)) {
+                                                        for (var i = 0; i < response.length; i++) {
+                                                                var item = response[i];
+                                                                if (item && item.resp && String(item.resp).toUpperCase() === 'OK') {
+                                                                        reopenSuccessful = true;
+                                                                        break;
+                                                                }
+                                                        }
+                                                }
+
+                                                if (reopenSuccessful) {
+                                                        if (statusInput) {
+                                                                statusInput.value = 'ASIGNADO';
+                                                        }
+                                                        originalStatus = statusInput ? statusInput.value : originalStatus;
+
+                                                        hideReopenModal(false);
+                                                        window.alert('La incidencia fue reabierta correctamente.');
+                                                } else {
+                                                        handleReopenError();
+                                                }
+                                        } catch (err) {
+                                                handleReopenError();
+                                        }
+                                } else {
+                                        handleReopenError();
+                                }
+                        };
+
+                        xhr.send(params);
+                });
+        }
 });
 </script>
 </head>
@@ -38,6 +199,23 @@ $(document).ready(function() {
 		<div class="col-xs-4 col-md-4"><input disabled type="text" id="frmtipomant" style="width:100%;" class="form-control"  placeholder="" value="<%=registro.getString("tipoorden")%>"/></div>
 		<div class="col-xs-2 col-md-2">Estatus:</div>
 		<div class="col-xs-4 col-md-4"><input disabled type="text" id="frmestatus" style="width:100%;" class="form-control"  placeholder="" value="<%=registro.getString("ESTATUS")%>"/></div>
+		<div class="col-xs-2 col-md-2" style="margin-top: 5px;">Reabrir Incidencia:</div>
+		<div class="col-xs-4 col-md-4" style="margin-top: 5px;">
+			<select id="frmreabririncidencia" class="form-control" style="width:100%;">
+				<option value="">Seleccione</option>
+				<option value="SI">SI</option>
+			</select>
+		</div>
+                <div id="reabrir-modal-overlay">
+                        <div id="reabrir-modal">
+                                <h4>Reabrir incidencia</h4>
+                                <p>&iquest;Desea reabrir la incidencia seleccionada?</p>
+                                <div class="modal-actions">
+                                        <button type="button" id="reabrirCancelar" class="btn btn-default">Cancelar</button>
+                                        <button type="button" id="reabrirAceptar" class="btn btn-primary">Aceptar</button>
+                                </div>
+                        </div>
+                </div>
 		<div class="col-xs-2" style="margin-top: 5px;">T&eacute;cnico Asignado:</div>
 		<div class="col-xs-4" style="margin-top: 5px;"><input disabled type="text" id="frmtecnicoasig" style="width:100%;" class="form-control"  placeholder="" value="<%=registro.getString("tecnico")%>"/></div>
 
@@ -308,7 +486,7 @@ $(document).ready(function() {
 				</div>
 				<div class="col-xs-2">Temperatura Operaci&oacute;n:</div>
 				<div class="col-xs-4">
-					<input disabled type="text" id="frmpuesto" style="width:100%;" class="form-control" value="<%=registro.getString("TEMPO")%> °<%=registro.getString("TEMPOUNI")%>" >
+					<input disabled type="text" id="frmpuesto" style="width:100%;" class="form-control" value="<%=registro.getString("TEMPO")%> Â°<%=registro.getString("TEMPOUNI")%>" >
 					
 				</div>
 			</div>

--- a/jsp/reanudarIncidencia.jsp
+++ b/jsp/reanudarIncidencia.jsp
@@ -1,0 +1,41 @@
+<%@page import="org.json.JSONObject" %>
+<%@page import="org.json.JSONArray" %>
+<%@page import="bean.GestionTareas" %>
+<%@ page language="java" contentType="application/json; charset=ISO-8859-1"
+    pageEncoding="ISO-8859-1"%>
+<%
+        String orden = request.getParameter("orden");
+        String usuario = request.getParameter("usuario") != null ? request.getParameter("usuario") : "";
+        String estatus = request.getParameter("estatus");
+        String actualestatus = request.getParameter("actualestatus") != null ? request.getParameter("actualestatus") : "";
+        String idaccion = request.getParameter("idaccion");
+
+        JSONArray respuesta = new JSONArray();
+
+        try {
+                if (orden == null || orden.trim().isEmpty()) {
+                        JSONObject error = new JSONObject();
+                        error.put("resp", "ERROR");
+                        error.put("mensaje", "Identificador de orden no proporcionado.");
+                        respuesta.put(error);
+                } else {
+                        if (estatus == null || estatus.trim().isEmpty()) {
+                                estatus = "2";
+                        }
+                        if (idaccion == null || idaccion.trim().isEmpty()) {
+                                idaccion = "REANUDAR";
+                        }
+
+                        GestionTareas gestion = new GestionTareas();
+                        respuesta = gestion.reanudarTarea(orden, usuario, estatus, actualestatus, idaccion);
+                }
+        } catch (Exception ex) {
+                JSONObject error = new JSONObject();
+                error.put("resp", "ERROR");
+                error.put("mensaje", ex.getMessage() != null ? ex.getMessage() : "Error al reabrir la incidencia.");
+                respuesta = new JSONArray();
+                respuesta.put(error);
+        }
+
+        out.print(respuesta.toString());
+%>


### PR DESCRIPTION
## Summary
- add a confirmation modal and vanilla-JS logic in `detalle.jsp` to reopen incidents, set the status to ASIGNADO when selecting "SI", and reset the selection when cancelled
- expose a small JSP endpoint that calls `GestionTareas.reanudarTarea` with status 2 to persist the reopening

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf19f43b048332aa89ccff8cdbb062