### PR TITLE
Increment reopen counter when reopening tasks

### DIFF
--- a/src/bean/GestionTareasReabrirIncidencia.java
+++ b/src/bean/GestionTareasReabrirIncidencia.java
@@ -35,7 +35,7 @@ public class GestionTareasReabrirIncidencia {
 
                       try (Connection conn = conexion.getConnection();
                            PreparedStatement pst = conn != null
-                              ? conn.prepareStatement("update csorden set IdEstatusOrden=? where FolioOrden=?")
+                              ? conn.prepareStatement("update csorden set IdEstatusOrden=?, ContadorReabierto = COALESCE(ContadorReabierto, 0) + 1 where FolioOrden=?")
                               : null) {
 
                          if (conn == null) {


### PR DESCRIPTION
## Summary
- increment the ContadorReabierto value whenever an order is reopened

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db69bd5270833295d50f993de19b97