### PR TITLE
Add Angular 18 business site with SQL-backed order chat assistant

### DIFF
--- a/angular-business-site/angular.json
+++ b/angular-business-site/angular.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "coolservice-business-site": {
+      "projectType": "application",
+      "schematics": {},
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:application",
+          "options": {
+            "outputPath": "dist/coolservice-business-site",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": [],
+            "tsConfig": "tsconfig.app.json",
+            "assets": ["src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "buildTarget": "coolservice-business-site:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "tsConfig": "tsconfig.spec.json",
+            "polyfills": [],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/angular-business-site/package.json
+++ b/angular-business-site/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "coolservice-business-site",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test"
+  },
+  "dependencies": {
+    "@angular/animations": "^18.2.0",
+    "@angular/common": "^18.2.0",
+    "@angular/compiler": "^18.2.0",
+    "@angular/core": "^18.2.0",
+    "@angular/forms": "^18.2.0",
+    "@angular/platform-browser": "^18.2.0",
+    "@angular/platform-browser-dynamic": "^18.2.0",
+    "@angular/router": "^18.2.0",
+    "rxjs": "^7.8.1",
+    "tslib": "^2.6.2",
+    "zone.js": "^0.14.10"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^18.2.0",
+    "@angular/cli": "^18.2.0",
+    "@angular/compiler-cli": "^18.2.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/angular-business-site/src/app/app.component.css
+++ b/angular-business-site/src/app/app.component.css
@@ -1,0 +1,68 @@
+.site-header {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  border-bottom: 1px solid var(--color-border);
+  z-index: 10;
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1.2rem 0;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.logo strong {
+  display: block;
+  color: var(--color-dark);
+}
+
+.logo small {
+  color: var(--color-text);
+  font-size: 0.8rem;
+}
+
+.nav {
+  display: flex;
+  gap: 1.5rem;
+  font-weight: 700;
+}
+
+.nav a {
+  color: var(--color-text);
+  position: relative;
+}
+
+.nav a.active,
+.nav a:hover {
+  color: var(--color-primary);
+}
+
+.nav a.active::after {
+  content: '';
+  position: absolute;
+  bottom: -0.4rem;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--color-accent);
+}
+
+@media (max-width: 900px) {
+  .header-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .nav {
+    flex-wrap: wrap;
+  }
+}

--- a/angular-business-site/src/app/app.component.html
+++ b/angular-business-site/src/app/app.component.html
@@ -1,0 +1,43 @@
+<header class="site-header">
+  <div class="container header-inner">
+    <div class="logo">
+      <span class="badge">CoolService</span>
+      <div>
+        <strong>Business Studio</strong>
+        <small>Reliable operations & customer care</small>
+      </div>
+    </div>
+    <nav class="nav">
+      <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Home</a>
+      <a routerLink="/services" routerLinkActive="active">Services</a>
+      <a routerLink="/about" routerLinkActive="active">About</a>
+      <a routerLink="/contact" routerLinkActive="active">Contact</a>
+    </nav>
+    <a class="btn btn-primary" routerLink="/contact">Get a Quote</a>
+  </div>
+</header>
+
+<main>
+  <router-outlet></router-outlet>
+</main>
+
+<footer class="footer">
+  <div class="container">
+    <div>
+      <h3>CoolService</h3>
+      <p>Professional service operations aligned with modern customer experiences.</p>
+    </div>
+    <div>
+      <strong>Contact</strong>
+      <p>hello@coolservice.io<br />+1 (555) 120-9955</p>
+    </div>
+    <div>
+      <strong>Office</strong>
+      <p>1234 Meridian Avenue<br />Miami, FL 33101</p>
+    </div>
+    <div>
+      <strong>Follow</strong>
+      <p><a href="https://example.com">LinkedIn</a> · <a href="https://example.com">Instagram</a></p>
+    </div>
+  </div>
+</footer>

--- a/angular-business-site/src/app/app.component.ts
+++ b/angular-business-site/src/app/app.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [RouterOutlet, RouterLink, RouterLinkActive],
+  templateUrl: './app.component.html',
+  styleUrl: './app.component.css'
+})
+export class AppComponent {}

--- a/angular-business-site/src/app/app.routes.ts
+++ b/angular-business-site/src/app/app.routes.ts
@@ -1,0 +1,13 @@
+import { Routes } from '@angular/router';
+import { HomeComponent } from './pages/home/home.component';
+import { ServicesComponent } from './pages/services/services.component';
+import { AboutComponent } from './pages/about/about.component';
+import { ContactComponent } from './pages/contact/contact.component';
+
+export const routes: Routes = [
+  { path: '', component: HomeComponent },
+  { path: 'services', component: ServicesComponent },
+  { path: 'about', component: AboutComponent },
+  { path: 'contact', component: ContactComponent },
+  { path: '**', redirectTo: '' }
+];

--- a/angular-business-site/src/app/components/chat-assistant/chat-assistant.component.css
+++ b/angular-business-site/src/app/components/chat-assistant/chat-assistant.component.css
@@ -1,0 +1,88 @@
+.chat-card {
+  background: #fff;
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 22px 40px rgba(0, 92, 155, 0.12);
+  padding: 1.8rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.chat-header h3 {
+  margin: 0.5rem 0;
+  color: var(--color-dark);
+}
+
+.chat-header p {
+  margin: 0;
+}
+
+.chat-body {
+  display: grid;
+  gap: 0.75rem;
+  max-height: 260px;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.chat-message {
+  display: flex;
+}
+
+.chat-message.user {
+  justify-content: flex-end;
+}
+
+.bubble {
+  background: var(--color-soft);
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  max-width: 85%;
+  color: var(--color-dark);
+}
+
+.chat-message.user .bubble {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.chat-input {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.chat-input input {
+  flex: 1;
+}
+
+.chat-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.85rem;
+}
+
+.chat-suggestions span {
+  color: var(--color-text);
+}
+
+.chip {
+  border: 1px solid var(--color-border);
+  background: #fff;
+  border-radius: 999px;
+  padding: 0.3rem 0.8rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.chip:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+@media (max-width: 600px) {
+  .chat-input {
+    flex-direction: column;
+  }
+}

--- a/angular-business-site/src/app/components/chat-assistant/chat-assistant.component.html
+++ b/angular-business-site/src/app/components/chat-assistant/chat-assistant.component.html
@@ -1,0 +1,35 @@
+<div class="chat-card">
+  <div class="chat-header">
+    <div>
+      <span class="badge">Chat SQL</span>
+      <h3>Asistente de orden de servicio</h3>
+      <p>Consulta en segundos el estatus de tus órdenes conectadas a tu base de datos.</p>
+    </div>
+  </div>
+
+  <div class="chat-body">
+    <div class="chat-message" *ngFor="let message of messages" [class.user]="message.from === 'user'">
+      <div class="bubble">{{ message.text }}</div>
+    </div>
+    <div class="chat-message" *ngIf="loading">
+      <div class="bubble">Buscando en SQL…</div>
+    </div>
+  </div>
+
+  <form class="chat-input" (ngSubmit)="sendMessage()">
+    <input
+      type="text"
+      placeholder="Ingresa tu orden (OS-1042)"
+      [(ngModel)]="input"
+      name="orden"
+    />
+    <button class="btn btn-primary" type="submit">Consultar</button>
+  </form>
+
+  <div class="chat-suggestions">
+    <span>Órdenes recientes:</span>
+    <button class="chip" *ngFor="let orden of featuredOrdenes" type="button" (click)="input = orden.id">
+      {{ orden.id }}
+    </button>
+  </div>
+</div>

--- a/angular-business-site/src/app/components/chat-assistant/chat-assistant.component.ts
+++ b/angular-business-site/src/app/components/chat-assistant/chat-assistant.component.ts
@@ -1,0 +1,60 @@
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { NgFor, NgIf } from '@angular/common';
+import { OrdenesService, OrdenServicio } from '../../services/ordenes.service';
+
+interface ChatMessage {
+  from: 'assistant' | 'user';
+  text: string;
+}
+
+@Component({
+  selector: 'app-chat-assistant',
+  standalone: true,
+  imports: [FormsModule, NgFor, NgIf],
+  templateUrl: './chat-assistant.component.html',
+  styleUrl: './chat-assistant.component.css'
+})
+export class ChatAssistantComponent {
+  messages: ChatMessage[] = [
+    {
+      from: 'assistant',
+      text: 'Hola, soy el asistente de órdenes. Comparte un número de orden (ej: OS-2048) y lo consultaré en la base SQL.'
+    }
+  ];
+  input = '';
+  loading = false;
+  featuredOrdenes: OrdenServicio[] = [];
+
+  constructor(private ordenesService: OrdenesService) {
+    this.ordenesService.getFeaturedOrdenes().subscribe((ordenes) => {
+      this.featuredOrdenes = ordenes;
+    });
+  }
+
+  sendMessage() {
+    const trimmed = this.input.trim();
+    if (!trimmed || this.loading) {
+      return;
+    }
+
+    this.messages.push({ from: 'user', text: trimmed });
+    this.input = '';
+    this.loading = true;
+
+    this.ordenesService.lookupOrden(trimmed).subscribe((orden) => {
+      if (orden) {
+        this.messages.push({
+          from: 'assistant',
+          text: `Orden ${orden.id} · ${orden.cliente} — Estado: ${orden.estado}. Técnico: ${orden.tecnico}. ${orden.ultimaActualizacion}.`
+        });
+      } else {
+        this.messages.push({
+          from: 'assistant',
+          text: `No encontré la orden ${trimmed}. Puedes revisar el ID o solicitar una búsqueda avanzada.`
+        });
+      }
+      this.loading = false;
+    });
+  }
+}

--- a/angular-business-site/src/app/pages/about/about.component.css
+++ b/angular-business-site/src/app/pages/about/about.component.css
@@ -1,0 +1,14 @@
+.about-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.about-grid ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+}
+
+.about-grid li {
+  margin-bottom: 0.4rem;
+}

--- a/angular-business-site/src/app/pages/about/about.component.html
+++ b/angular-business-site/src/app/pages/about/about.component.html
@@ -1,0 +1,54 @@
+<section class="section">
+  <div class="container">
+    <span class="badge">About</span>
+    <h1 class="section-title">We build service experiences that feel effortless.</h1>
+    <p class="section-subtitle">
+      CoolService is a multidisciplinary team of strategists, engineers, and customer success leaders dedicated
+      to helping service organizations scale with confidence.
+    </p>
+    <div class="about-grid">
+      <div class="card">
+        <h3>Our Mission</h3>
+        <p>
+          Empower service teams with real-time data, clear workflows, and customer-centric communication that
+          builds trust at every interaction.
+        </p>
+      </div>
+      <div class="card">
+        <h3>Our Values</h3>
+        <ul>
+          <li>Transparency across every service order.</li>
+          <li>Operational excellence with human empathy.</li>
+          <li>Continuous improvement driven by insights.</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Leadership Snapshot</h3>
+        <p>
+          Our leadership team combines 40+ years of experience in field operations, SaaS, and enterprise
+          customer experience.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section soft">
+  <div class="container">
+    <h2 class="section-title">Milestones</h2>
+    <div class="card-grid">
+      <div class="card">
+        <h3>2018</h3>
+        <p>Founded to modernize service order management for regional providers.</p>
+      </div>
+      <div class="card">
+        <h3>2021</h3>
+        <p>Expanded to multi-location operations across North America.</p>
+      </div>
+      <div class="card">
+        <h3>2024</h3>
+        <p>Launched AI-assisted service insights with SQL-ready integrations.</p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/angular-business-site/src/app/pages/about/about.component.ts
+++ b/angular-business-site/src/app/pages/about/about.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-about',
+  standalone: true,
+  templateUrl: './about.component.html',
+  styleUrl: './about.component.css'
+})
+export class AboutComponent {}

--- a/angular-business-site/src/app/pages/contact/contact.component.css
+++ b/angular-business-site/src/app/pages/contact/contact.component.css
@@ -1,0 +1,16 @@
+.contact-grid {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.contact-grid .card {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.contact-grid h3 {
+  margin: 1rem 0 0;
+  color: var(--color-primary);
+}

--- a/angular-business-site/src/app/pages/contact/contact.component.html
+++ b/angular-business-site/src/app/pages/contact/contact.component.html
@@ -1,0 +1,34 @@
+<section class="section">
+  <div class="container contact-grid">
+    <div>
+      <span class="badge">Contact</span>
+      <h1 class="section-title">Let’s build your next service experience.</h1>
+      <p class="section-subtitle">
+        Share your goals and we’ll create a tailored plan for service operations, analytics, and customer care.
+      </p>
+      <div class="card">
+        <h3>Visit Us</h3>
+        <p>1234 Meridian Avenue<br />Miami, FL 33101</p>
+        <h3>Call</h3>
+        <p>+1 (555) 120-9955</p>
+        <h3>Email</h3>
+        <p>hello@coolservice.io</p>
+      </div>
+    </div>
+    <div class="card">
+      <h2 class="section-title">Request a consultation</h2>
+      <form class="form">
+        <input type="text" placeholder="Full name" />
+        <input type="email" placeholder="Business email" />
+        <select>
+          <option>Service Operations Strategy</option>
+          <option>SQL Integrations</option>
+          <option>Customer Communications</option>
+          <option>Performance Analytics</option>
+        </select>
+        <textarea placeholder="Tell us about your service goals"></textarea>
+        <button class="btn btn-primary" type="button">Submit Request</button>
+      </form>
+    </div>
+  </div>
+</section>

--- a/angular-business-site/src/app/pages/contact/contact.component.ts
+++ b/angular-business-site/src/app/pages/contact/contact.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-contact',
+  standalone: true,
+  imports: [FormsModule],
+  templateUrl: './contact.component.html',
+  styleUrl: './contact.component.css'
+})
+export class ContactComponent {}

--- a/angular-business-site/src/app/pages/home/home.component.css
+++ b/angular-business-site/src/app/pages/home/home.component.css
@@ -1,0 +1,107 @@
+.hero {
+  background: linear-gradient(135deg, var(--color-soft), #fff);
+  padding: 5rem 0 4rem;
+}
+
+.hero-grid {
+  display: grid;
+  gap: 3rem;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.hero h1 {
+  font-size: 2.7rem;
+  color: var(--color-dark);
+  margin: 1rem 0;
+}
+
+.hero p {
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 1.5rem;
+}
+
+.hero-stats {
+  display: flex;
+  gap: 2rem;
+  margin-top: 2rem;
+  flex-wrap: wrap;
+}
+
+.hero-stats strong {
+  display: block;
+  font-size: 1.4rem;
+  color: var(--color-primary);
+}
+
+.hero-card {
+  background: #fff;
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 24px 50px rgba(0, 92, 155, 0.12);
+  border: 1px solid var(--color-border);
+}
+
+.hero-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.hero-card li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 700;
+  color: var(--color-dark);
+}
+
+.hero-card span {
+  font-weight: 400;
+  color: var(--color-text);
+}
+
+.split {
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.timeline {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline li {
+  background: #fff;
+  border-radius: 1rem;
+  padding: 1.3rem 1.5rem;
+  border: 1px solid var(--color-border);
+}
+
+.timeline strong {
+  color: var(--color-primary);
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding: 4rem 0 3rem;
+  }
+
+  .hero h1 {
+    font-size: 2.2rem;
+  }
+}

--- a/angular-business-site/src/app/pages/home/home.component.html
+++ b/angular-business-site/src/app/pages/home/home.component.html
@@ -1,0 +1,103 @@
+<section class="hero">
+  <div class="container hero-grid">
+    <div>
+      <span class="badge">Trusted Service Operations</span>
+      <h1>Powering efficient teams and memorable client experiences.</h1>
+      <p>
+        CoolService delivers end-to-end business support, including real-time service order insights,
+        proactive monitoring, and customer-first communication.
+      </p>
+      <div class="hero-actions">
+        <a class="btn btn-primary" routerLink="/contact">Schedule a Consultation</a>
+        <a class="btn btn-outline" routerLink="/services">Explore Services</a>
+      </div>
+      <div class="hero-stats">
+        <div>
+          <strong>98%</strong>
+          <span>Client retention</span>
+        </div>
+        <div>
+          <strong>24/7</strong>
+          <span>Support coverage</span>
+        </div>
+        <div>
+          <strong>320+</strong>
+          <span>Service orders tracked monthly</span>
+        </div>
+      </div>
+    </div>
+    <div class="hero-card">
+      <h3>Service Health Snapshot</h3>
+      <ul>
+        <li>
+          <span>Active Orders</span>
+          <strong>142</strong>
+        </li>
+        <li>
+          <span>Average SLA</span>
+          <strong>3.2 hrs</strong>
+        </li>
+        <li>
+          <span>Customer NPS</span>
+          <strong>+64</strong>
+        </li>
+      </ul>
+      <p>Dashboards are synced with your SQL service database every 15 minutes.</p>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <h2 class="section-title">Business services built for modern teams</h2>
+    <p class="section-subtitle">
+      From field operations to customer communications, our solutions adapt to the way your team works.
+    </p>
+    <div class="card-grid">
+      <div class="card">
+        <h3>Operational Excellence</h3>
+        <p>Standardize workflows, elevate service quality, and maintain compliance across every site.</p>
+      </div>
+      <div class="card">
+        <h3>Order Intelligence</h3>
+        <p>Connect directly to your SQL data to surface order status, history, and next actions.</p>
+      </div>
+      <div class="card">
+        <h3>Client Experience</h3>
+        <p>Keep customers informed with transparent updates and personalized touchpoints.</p>
+      </div>
+      <div class="card">
+        <h3>Performance Insights</h3>
+        <p>Monitor KPIs with live dashboards and tailor strategies with data-backed insights.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section soft">
+  <div class="container split">
+    <div>
+      <h2 class="section-title">How we support your service lifecycle</h2>
+      <p class="section-subtitle">A proven framework to move requests from intake to resolution.</p>
+      <ol class="timeline">
+        <li>
+          <strong>Discover</strong>
+          <p>We analyze your existing workflows, systems, and service volume.</p>
+        </li>
+        <li>
+          <strong>Design</strong>
+          <p>We map a digital-first journey and define SLA-driven milestones.</p>
+        </li>
+        <li>
+          <strong>Deploy</strong>
+          <p>We integrate with your SQL database and launch branded communications.</p>
+        </li>
+        <li>
+          <strong>Delight</strong>
+          <p>We track every order and empower teams with proactive insights.</p>
+        </li>
+      </ol>
+    </div>
+    <app-chat-assistant></app-chat-assistant>
+  </div>
+</section>

--- a/angular-business-site/src/app/pages/home/home.component.ts
+++ b/angular-business-site/src/app/pages/home/home.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ChatAssistantComponent } from '../../components/chat-assistant/chat-assistant.component';
+
+@Component({
+  selector: 'app-home',
+  standalone: true,
+  imports: [ChatAssistantComponent, RouterLink],
+  templateUrl: './home.component.html',
+  styleUrl: './home.component.css'
+})
+export class HomeComponent {}

--- a/angular-business-site/src/app/pages/services/services.component.css
+++ b/angular-business-site/src/app/pages/services/services.component.css
@@ -1,0 +1,3 @@
+.services-hero {
+  padding-bottom: 2rem;
+}

--- a/angular-business-site/src/app/pages/services/services.component.html
+++ b/angular-business-site/src/app/pages/services/services.component.html
@@ -1,0 +1,50 @@
+<section class="section services-hero">
+  <div class="container">
+    <span class="badge">Services</span>
+    <h1 class="section-title">Comprehensive support for every phase of service delivery</h1>
+    <p class="section-subtitle">
+      We blend operational strategy, technical enablement, and customer engagement to keep your teams moving fast.
+    </p>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container card-grid">
+    <div class="card">
+      <h3>Service Order Hub</h3>
+      <p>Centralize order intake, automate routing, and sync status updates with your SQL database.</p>
+    </div>
+    <div class="card">
+      <h3>Field Team Enablement</h3>
+      <p>Provide technicians with mobile-ready playbooks, asset history, and real-time checklists.</p>
+    </div>
+    <div class="card">
+      <h3>Customer Communications</h3>
+      <p>Deliver branded notifications, appointment reminders, and follow-up surveys.</p>
+    </div>
+    <div class="card">
+      <h3>Business Intelligence</h3>
+      <p>Track KPIs, SLA adherence, and cost-per-order with executive dashboards.</p>
+    </div>
+  </div>
+</section>
+
+<section class="section soft">
+  <div class="container">
+    <h2 class="section-title">Add-on solutions</h2>
+    <div class="card-grid">
+      <div class="card">
+        <h3>Supply Chain Visibility</h3>
+        <p>Monitor parts availability and reduce downtime with predictive alerts.</p>
+      </div>
+      <div class="card">
+        <h3>Quality Assurance</h3>
+        <p>Automate inspection workflows and store evidence for compliance reviews.</p>
+      </div>
+      <div class="card">
+        <h3>Training &amp; Adoption</h3>
+        <p>Launch enablement programs tailored to new process rollouts.</p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/angular-business-site/src/app/pages/services/services.component.ts
+++ b/angular-business-site/src/app/pages/services/services.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-services',
+  standalone: true,
+  templateUrl: './services.component.html',
+  styleUrl: './services.component.css'
+})
+export class ServicesComponent {}

--- a/angular-business-site/src/app/services/ordenes.service.ts
+++ b/angular-business-site/src/app/services/ordenes.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { catchError, of } from 'rxjs';
+
+export interface OrdenServicio {
+  id: string;
+  cliente: string;
+  estado: string;
+  tecnico: string;
+  ultimaActualizacion: string;
+}
+
+const MOCK_ORDENES: OrdenServicio[] = [
+  {
+    id: 'OS-1042',
+    cliente: 'Grupo Altura',
+    estado: 'En ruta',
+    tecnico: 'Mariana Soto',
+    ultimaActualizacion: 'Hace 18 minutos'
+  },
+  {
+    id: 'OS-2048',
+    cliente: 'Logística Rivera',
+    estado: 'En diagnóstico',
+    tecnico: 'Luis Ávila',
+    ultimaActualizacion: 'Hace 42 minutos'
+  },
+  {
+    id: 'OS-3091',
+    cliente: 'Hotel Miramar',
+    estado: 'Completada',
+    tecnico: 'Andrea Campos',
+    ultimaActualizacion: 'Hoy, 9:12 AM'
+  }
+];
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OrdenesService {
+  constructor(private http: HttpClient) {}
+
+  lookupOrden(id: string) {
+    return this.http.get<OrdenServicio>(`/api/ordenes/${id}`).pipe(
+      catchError(() => {
+        const mock = MOCK_ORDENES.find((orden) => orden.id.toLowerCase() === id.toLowerCase());
+        return of(mock ?? null);
+      })
+    );
+  }
+
+  getFeaturedOrdenes() {
+    return of(MOCK_ORDENES);
+  }
+}

--- a/angular-business-site/src/index.html
+++ b/angular-business-site/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>CoolService | Business Solutions</title>
+    <base href="/">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Professional business services with a modern Angular experience.">
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/angular-business-site/src/main.ts
+++ b/angular-business-site/src/main.ts
@@ -1,0 +1,9 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import { AppComponent } from './app/app.component';
+import { routes } from './app/app.routes';
+
+bootstrapApplication(AppComponent, {
+  providers: [provideHttpClient(), provideRouter(routes)]
+}).catch((err) => console.error(err));

--- a/angular-business-site/src/styles.css
+++ b/angular-business-site/src/styles.css
@@ -1,0 +1,165 @@
+@import url('https://fonts.googleapis.com/css2?family=Ruda:wght@400;700;900&display=swap');
+
+:root {
+  --color-primary: #005c9b;
+  --color-primary-strong: #0090d3;
+  --color-accent: #68dff0;
+  --color-text: #797979;
+  --color-dark: #1a1a1a;
+  --color-bg: #ffffff;
+  --color-soft: #f5fbff;
+  --color-border: #e3e7ef;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Ruda', sans-serif;
+  color: var(--color-text);
+  background: var(--color-bg);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(1100px, 90vw);
+  margin: 0 auto;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 700;
+  transition: all 0.2s ease;
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: var(--color-primary-strong);
+}
+
+.btn-outline {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: transparent;
+}
+
+.badge {
+  background: var(--color-accent);
+  color: #fff;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.section {
+  padding: 4.5rem 0;
+}
+
+.soft {
+  background: var(--color-soft);
+}
+
+.section-title {
+  color: var(--color-dark);
+  font-size: 2.1rem;
+  margin: 0 0 1rem 0;
+}
+
+.section-subtitle {
+  color: var(--color-text);
+  max-width: 640px;
+  margin-bottom: 2rem;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: #fff;
+  border: 1px solid var(--color-border);
+  border-radius: 1.5rem;
+  padding: 1.6rem;
+  box-shadow: 0 20px 40px rgba(0, 92, 155, 0.08);
+}
+
+.card h3 {
+  color: var(--color-dark);
+  margin: 0 0 0.5rem 0;
+}
+
+.card p {
+  margin: 0;
+}
+
+.form {
+  display: grid;
+  gap: 1rem;
+}
+
+.form input,
+.form textarea,
+.form select {
+  width: 100%;
+  padding: 0.8rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--color-border);
+  font-family: inherit;
+}
+
+.form textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.footer {
+  background: var(--color-dark);
+  color: #fff;
+  padding: 2.5rem 0;
+}
+
+.footer .container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.footer a {
+  color: var(--color-accent);
+}
+
+@media (max-width: 768px) {
+  .section {
+    padding: 3.5rem 0;
+  }
+
+  .section-title {
+    font-size: 1.8rem;
+  }
+}

--- a/angular-business-site/tsconfig.app.json
+++ b/angular-business-site/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc/app",
+    "types": []
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/angular-business-site/tsconfig.json
+++ b/angular-business-site/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "bundler",
+    "importHelpers": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "useDefineForClassFields": false,
+    "lib": ["ES2022", "dom"]
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/angular-business-site/tsconfig.spec.json
+++ b/angular-business-site/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc/spec",
+    "types": ["jasmine"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
### Motivation
- Provide a professional, Angular-based business website scaffold (latest Angular 18) that adopts the repository's colors and `Ruda` font for consistent branding.
- Include standard marketing pages (Home, Services, About, Contact) populated with realistic dummy content so the site is immediately usable as a prototype.
- Add an interactive chat assistant that can look up service orders in a SQL-backed API with a safe mock fallback when the backend is unavailable.

### Description
- Scaffolds a standalone Angular application under `angular-business-site/` with `package.json`, `angular.json`, `tsconfig*.json`, `src/main.ts`, and `src/index.html` to run and build the app.
- Adds global styling in `src/styles.css` that imports the `Ruda` font and defines the color variables used across the site to match the repository palette.
- Implements shared layout and routing via `AppComponent` and `app.routes.ts`, and creates standalone pages: `HomeComponent`, `ServicesComponent`, `AboutComponent`, and `ContactComponent` with markup and page-level styles.
- Implements `ChatAssistantComponent` UI and `OrdenesService` which queries `/api/ordenes/:id` and falls back to `MOCK_ORDENES` when the HTTP call fails, and embeds the chat assistant on the Home page.

### Testing
- Attempted to install dependencies with `npm install` in `angular-business-site/`, but the run failed with `403 Forbidden` from the npm registry so the application build and runtime tests could not be executed.
- No automated unit or integration tests were executed because dependency installation failed (see `npm install` error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69841d3db34883328c21bebbf16dbd4f)